### PR TITLE
Make window not resizable in Linux

### DIFF
--- a/olcPGEX_Sound.h
+++ b/olcPGEX_Sound.h
@@ -167,7 +167,7 @@ namespace olc
 
 	private:
 #ifdef USE_WINDOWS // Windows specific sound management
-		static void CALLBACK waveOutProc(HWAVEOUT hWaveOut, UINT uMsg, DWORD dwParam1, DWORD dwParam2);
+		static void CALLBACK SOUND::waveOutProc(HWAVEOUT hWaveOut, UINT uMsg, DWORD_PTR dwInstance, DWORD dwParam1, DWORD dwParam2);
 		static unsigned int m_nSampleRate;
 		static unsigned int m_nChannels;
 		static unsigned int m_nBlockCount;
@@ -501,7 +501,7 @@ namespace olc
 	}
 
 	// Handler for soundcard request for more data
-	void CALLBACK SOUND::waveOutProc(HWAVEOUT hWaveOut, UINT uMsg, DWORD dwParam1, DWORD dwParam2)
+	void CALLBACK SOUND::waveOutProc(HWAVEOUT hWaveOut, UINT uMsg, DWORD_PTR dwInstance, DWORD dwParam1, DWORD dwParam2)
 	{
 		if (uMsg != WOM_DONE) return;
 		m_nBlockFree++;

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -576,6 +576,7 @@ namespace olc // All OneLoneCoder stuff will now exist in the "olc" namespace
 		XVisualInfo*            olc_VisualInfo;
 		Colormap                olc_ColourMap;
 		XSetWindowAttributes    olc_SetWindowAttribs;
+		XSizeHints			    olc_SizeHints;
 		Display*				olc_WindowCreate();
 #endif
 
@@ -2244,6 +2245,14 @@ namespace olc
 			nWindowWidth = gwa.width;
 			nWindowHeight = gwa.height;
 			olc_UpdateViewport();
+		} else {
+			olc_SizeHints.flags = PMaxSize | PMinSize;
+			olc_SizeHints.max_width = nScreenWidth * nPixelWidth;
+			olc_SizeHints.max_height = nScreenHeight * nPixelHeight;
+			olc_SizeHints.min_width = nScreenWidth * nPixelWidth;
+			olc_SizeHints.min_height = nScreenHeight * nPixelHeight;
+
+			XSetWMNormalHints(olc_Display, olc_Window, &olc_SizeHints);
 		}
 
 		// Create Keyboard Mapping


### PR DESCRIPTION
PGE window have fixed size in Windows, but in Linux it isn't. 
I think all platforms should have similar behavior.

Also it's glitching in resized area.
![OneLoneCoder com - Pixel Game Engine - Awoorwa - FPS: 60_004](https://user-images.githubusercontent.com/1898032/63950904-8574db80-ca85-11e9-91a3-012147ce929b.jpg)
