### PR TITLE
Fix MSVC bug with with getting C++ versions

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -262,6 +262,8 @@
     namespace _gfs = std::experimental::filesystem::v1;
 #endif
 
+#undef CPP_17
+
 #undef min
 #undef max
 #define UNUSED(x) (void)(x)

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -246,14 +246,20 @@
 #include <functional>
 #include <algorithm>
 
-#if __cplusplus >= 201703L
-	// C++17 onwards
-	#include <filesystem>
-	namespace _gfs = std::filesystem;
+#if _MSC_VER && !__INTEL_COMPILER
+    #define CPP_17 _HAS_CXX17
+#else 
+    #define CPP_17 __cplusplus >= 201703L
+#endif
+
+#if CPP_17
+    // C++17 onwards
+    #include <filesystem>
+    namespace _gfs = std::filesystem;
 #else
-	// Older "Modern" C++ :P
-	#include <experimental/filesystem>
-	namespace _gfs = std::experimental::filesystem::v1;
+    // Older "Modern" C++ :P
+    #include <experimental/filesystem>
+    namespace _gfs = std::experimental::filesystem::v1;
 #endif
 
 #undef min


### PR DESCRIPTION
MSVC C++ `__cplusplus` macro isn't going to give the right value unless `/Zc:__cplusplus` is used as a compilation flag ([see here](https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/)).

This in turn makes all checks on that macro invalid and causes compilation to fail because `std::experimental::filesystem::v1` is deprecated.

Instead, use MSVC intrinsic macros to check the C++ version when that compiler is used.