### PR TITLE
Fix MinGW

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -247,7 +247,7 @@
 #include <algorithm>
 
 #if defined(_WIN32)
-	#if _MSVC_LANG >= 201703L // Thanks @slavka
+	#if _MSVC_LANG >= 201703L || __cplusplus >= 201703L// Thanks @slavka
 		// C++17 onwards
 		#include <filesystem>
 		namespace _gfs = std::filesystem;


### PR DESCRIPTION
According to the MSYS2 wiki: https://github.com/msys2/msys2/wiki/Porting

_WIN32 applies to MSVC as well as MINGW

checking for c++17 in the _WIN32 block ensures the proper inclusion of the filesystem library