### PR TITLE
Add Controls extension

### DIFF
--- a/Extensions/olcPGEX_Controls.h
+++ b/Extensions/olcPGEX_Controls.h
@@ -255,10 +255,10 @@ namespace olc
 				this->textYOffset = 0;
 				this->textScale = textScale;
 			}
-			void PlaceText(float tpx, float tpy)
+			void PlaceText(float textXOffset, float textYOffset)
 			{
-				textXOffset = tpx;
-				textYOffset = tpy;
+				this->textXOffset = textXOffset;
+				this->textYOffset = textYOffset;
 			}
 			float GetX() override
 			{
@@ -313,7 +313,7 @@ namespace olc
 			float width;
 			float height;
 			float value;
-			float targetValue = 0.0f;
+			//float targetValue = 0.0f;
 			olc::Pixel backgroundColor;
 			olc::Pixel foregroundColor;
 			Orientation orientation;
@@ -369,7 +369,7 @@ namespace olc
 			}
 			void Increment(float incrementValue)
 			{
-				targetValue = value + incrementValue;
+				value = value + incrementValue;
 				H_CValueChanged(this, value);
 			}
 			/* Only Increments if value in range */
@@ -379,7 +379,7 @@ namespace olc
 					Increment(incrementValue);
 			}
 			void Decrement(float decrementValue) {
-				targetValue = value - decrementValue;
+				value = value - decrementValue;
 				H_CValueChanged(this, value);
 			}
 			/* Only Decrements if value in range */
@@ -394,7 +394,7 @@ namespace olc
 				{
 					H_CValueChanged(this, value);
 				}
-				targetValue = newValue;
+				value = newValue;
 			}
 			float GetValue()
 			{
@@ -421,19 +421,22 @@ namespace olc
 				}
 
 				// Smooth progress bars
-				if ((int)value != (int)targetValue)
+				/*if ((int)value != (int)targetValue)
 				{
 					if ((int)targetValue < (int)value)
 					{
-						if (!IsEmpty())
-							value -= 0.4f;
+						if (value+1 >= 0)
+							value -= 0.2f;
+						else
+							if (value > targetValue)
+								value = 0;
 					}
 					else if ((int)targetValue > (int)value)
 					{
-						if (!IsFull())
+						if (value <= 100)
 							value += 0.4f;
 					}
-				}
+				}*/
 				float newWidth = width;
 				float newHeight = height;
 				switch (orientation)
@@ -607,8 +610,8 @@ namespace olc
 				this->textScale = textScale;
 			}
 			void PlaceText(float textXOffset, float textYOffset) {
-				textXOffset = textXOffset;
-				textYOffset = textYOffset;
+				this->textXOffset = textXOffset;
+				this->textYOffset = textYOffset;
 			}
 			float GetX() override
 			{

--- a/Extensions/olcPGEX_Controls.h
+++ b/Extensions/olcPGEX_Controls.h
@@ -8,8 +8,7 @@
 	What is this?
 	~~~~~~~~~~~~~
 	This is an extension to the olcPixelGameEngine, which provides
-	basic controls and event
-	handling.
+	some basic controls and event handlers.
 
 	Example
 	~~~~~~~
@@ -94,9 +93,7 @@ namespace olc
 			pge = pixelGameEngine;
 		}
 
-		class BasicControl;
-
-		struct CBoundingBox
+		struct CBox
 		{
 			int x;
 			int y;
@@ -104,14 +101,30 @@ namespace olc
 			int height;
 		};
 
-		CBoundingBox* CreateBoundingBox(int x, int y, int width, int height)
+		CBox* CreateBox(int x, int y, int width, int height)
 		{
-			return new CBoundingBox{ x, y, width, height };
+			return new CBox{ x, y, width, height };
 		}
 
-		/*
-		Handles the events of BasicControls
-		*/
+		bool IsInBounds(CBox* box, int x, int y)
+		{
+			if (x > box->x && x <= box->x + box->width && y >= box->y && y <= box->y + box->height)
+			{
+				return true;
+			}
+			return false;
+		}
+
+		bool IsInBounds(int boxX, int boxY, int boxWidth, int boxHeight, int pointX, int pointY)
+		{
+			if (pointX > boxX && pointX <= boxX + boxWidth && pointY >= boxY && pointY <= boxY + boxHeight)
+			{
+				return true;
+			}
+			return false;
+		}
+
+		class BasicControl;
 		class CEventHandler
 		{
 		public:
@@ -125,6 +138,32 @@ namespace olc
 		{
 		public:
 			std::vector<CEventHandler*> eventHandlers;
+			bool lockHandlers = false;
+			bool lockUpdates = false;
+			void LockHandlers()
+			{
+				lockHandlers = true;
+			}
+			void FreeHandlers()
+			{
+				lockHandlers = false;
+			}
+			bool HandlersLocked()
+			{
+				return lockHandlers;
+			}
+			void LockUpdates()
+			{
+				lockUpdates = true;
+			}
+			void FreeUpdates()
+			{
+				lockUpdates = false;
+			}
+			bool UpdatesLocked()
+			{
+				return lockUpdates;
+			}
 			virtual float GetX()
 			{
 				return 0.0f;
@@ -144,44 +183,41 @@ namespace olc
 			{
 				return 0.0f;
 			}
-			virtual void UpdateControl() {}
+			virtual void UpdateSelf() {}
+			void UpdateControl()
+			{
+				if (!lockUpdates)
+					UpdateSelf();
+			}
 			void AddEventHandler(CEventHandler* evh)
 			{
-				eventHandlers.push_back(evh);
-			}
-			bool IsInBounds(int x, int y, int w, int h, int pointX, int pointY)
-			{
-				if (pointX > x && pointX <= x + w && pointY >= y && pointY <= y + h) {
-					return true;
-				}
-				return false;
-			}
-			bool IsInBounds(CBoundingBox* boundingBox, int pointX, int pointY)
-			{
-				return IsInBounds(boundingBox->x, boundingBox->y, boundingBox->width, boundingBox->height, pointX, pointY);
+				this->eventHandlers.push_back(evh);
 			}
 			void H_CClicked(BasicControl* ctrl)
 			{
 				for (CEventHandler* handler : eventHandlers)
-					handler->CClicked(pge, ctrl);
+					if (!lockHandlers)
+						handler->CClicked(pge, ctrl);
 			}
 			void H_CReleased(BasicControl* ctrl)
 			{
 				for (CEventHandler* handler : eventHandlers)
-					handler->CReleased(pge, ctrl);
+					if (!lockHandlers)
+						handler->CReleased(pge, ctrl);
 			}
 			void H_CHover(BasicControl* ctrl)
 			{
 				for (CEventHandler* handler : eventHandlers)
-					handler->CHover(pge, ctrl);
+					if (!lockHandlers)
+						handler->CHover(pge, ctrl);
 			}
 			void H_CValueChanged(BasicControl* ctrl, float newValue)
 			{
 				for (CEventHandler* handler : eventHandlers)
-					handler->CValueChanged(pge, ctrl, newValue);
+					if (!lockHandlers)
+						handler->CValueChanged(pge, ctrl, newValue);
 			}
 		};
-
 
 		/*
 		--------------------------------------------------
@@ -203,7 +239,8 @@ namespace olc
 			olc::Pixel foregroundColor;
 			olc::Pixel foregroundColorHover;
 			std::string text;
-			CButton(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "CButton", olc::Pixel backgroundColor = olc::Pixel(44, 62, 80), olc::Pixel backgroundColorHover = olc::Pixel(52, 73, 94), olc::Pixel foregroundColor = olc::Pixel(236, 240, 241), olc::Pixel foregroundColorHover = olc::Pixel(236, 240, 241))
+			int32_t textScale;
+			CButton(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "CButton", int32_t textScale = 2U, olc::Pixel backgroundColor = olc::Pixel(44, 62, 80), olc::Pixel backgroundColorHover = olc::Pixel(52, 73, 94), olc::Pixel foregroundColor = olc::Pixel(236, 240, 241), olc::Pixel foregroundColorHover = olc::Pixel(236, 240, 241))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -216,6 +253,7 @@ namespace olc
 				this->text = text;
 				this->textXOffset = 0;
 				this->textYOffset = 0;
+				this->textScale = textScale;
 			}
 			void PlaceText(float tpx, float tpy)
 			{
@@ -224,35 +262,35 @@ namespace olc
 			}
 			float GetX() override
 			{
-				return this->x;
+				return x;
 			}
 			float GetY() override
 			{
-				return this->y;
+				return y;
 			}
 			float GetWidth() override
 			{
-				return this->width;
+				return width;
 			}
 			float GetHeight() override
 			{
-				return this->height;
+				return height;
 			}
-			void UpdateControl() override
+			void UpdateSelf() override
 			{
 				olc::Pixel backgroundColor = this->backgroundColor;
 				olc::Pixel foregroundColor = this->foregroundColor;
 
-				CBoundingBox* boundingBox = CreateBoundingBox(x, y, width, height);
+				CBox* boundingBox = CreateBox(x, y, width, height);
 				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY())) {
-					backgroundColor = this->backgroundColorHover;
-					foregroundColor = this->foregroundColorHover;
+					backgroundColor = backgroundColorHover;
+					foregroundColor = foregroundColorHover;
 					H_CHover(this);
 				}
 				pge->FillRect(x, y, width, height, backgroundColor);
-				pge->DrawString(x + textXOffset, y + textYOffset, this->text, foregroundColor, 2);
+				pge->DrawString(x + textXOffset, y + textYOffset, text, foregroundColor, textScale);
 
-				if (IsInBounds(x, y, width, height, pge->GetMouseX(), pge->GetMouseY()))
+				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 				{
 					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
 					{
@@ -275,6 +313,7 @@ namespace olc
 			float width;
 			float height;
 			float value;
+			float targetValue = 0.0f;
 			olc::Pixel backgroundColor;
 			olc::Pixel foregroundColor;
 			Orientation orientation;
@@ -300,37 +339,37 @@ namespace olc
 			}
 			float GetX() override
 			{
-				return this->x;
+				return x;
 			}
 			float GetY() override
 			{
-				return this->y;
+				return y;
 			}
 			float GetWidth() override
 			{
-				return this->width;
+				return width;
 			}
 			float GetHeight() override
 			{
-				return this->height;
+				return height;
 			}
 			/* Gets the progress size of horizontal progressbar */
 			float GetProgressWidth()
 			{
-				return (this->width / 100) * value;
+				return (width / 100) * value;
 			}
 			/* Gets the progress size of vertical progressbar */
 			float GetProgressHeight()
 			{
-				return (this->width / 100) * value;
+				return (width / 100) * value;
 			}
 			Orientation GetOrientation()
 			{
-				return this->orientation;
+				return orientation;
 			}
 			void Increment(float incrementValue)
 			{
-				value += incrementValue;
+				targetValue = value + incrementValue;
 				H_CValueChanged(this, value);
 			}
 			/* Only Increments if value in range */
@@ -340,7 +379,7 @@ namespace olc
 					Increment(incrementValue);
 			}
 			void Decrement(float decrementValue) {
-				this->value -= decrementValue;
+				targetValue = value - decrementValue;
 				H_CValueChanged(this, value);
 			}
 			/* Only Decrements if value in range */
@@ -355,7 +394,7 @@ namespace olc
 				{
 					H_CValueChanged(this, value);
 				}
-				value = newValue;
+				targetValue = newValue;
 			}
 			float GetValue()
 			{
@@ -369,9 +408,9 @@ namespace olc
 			{
 				return value <= 0;
 			}
-			void UpdateControl() override
+			void UpdateSelf() override
 			{
-				CBoundingBox* boundingBox = CreateBoundingBox(x, y, width, height);
+				CBox* boundingBox = CreateBox(x, y, width, height);
 				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 				{
 					H_CHover(this);
@@ -380,18 +419,33 @@ namespace olc
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
 						H_CReleased(this);
 				}
-				float newWidth = this->width;
-				float newHeight = this->height;
+
+				// Smooth progress bars
+				if ((int)value != (int)targetValue)
+				{
+					if ((int)targetValue < (int)value)
+					{
+						if (!IsEmpty())
+							value -= 0.4f;
+					}
+					else if ((int)targetValue > (int)value)
+					{
+						if (!IsFull())
+							value += 0.4f;
+					}
+				}
+				float newWidth = width;
+				float newHeight = height;
 				switch (orientation)
 				{
 				case HORIZONTAL:
-					newWidth = (this->width / 100) * this->value;
+					newWidth = (width / 100) * value;
 					break;
 				case VERTICAL:
-					newHeight = (this->height / 100) * this->value;
+					newHeight = (height / 100) * value;
 					break;
 				}
-				pge->FillRect(x, y, this->width, this->height, backgroundColor);
+				pge->FillRect(x, y, width, height, backgroundColor);
 				pge->FillRect(x, y, newWidth, newHeight, foregroundColor);
 				delete boundingBox;
 			}
@@ -424,27 +478,27 @@ namespace olc
 			}
 			float GetX() override
 			{
-				return this->x;
+				return x;
 			}
 			float GetY() override
 			{
-				return this->y;
+				return y;
 			}
 			float GetWidth() override
 			{
-				return this->size;
+				return size;
 			}
 			float GetHeight() override
 			{
-				return this->size;
+				return size;
 			}
 			void SetHeadOffset(float hoffset)
 			{
-				this->headOffset = hoffset;
+				headOffset = hoffset;
 			}
 			float GetHeadOffset()
 			{
-				return this->headOffset;
+				return headOffset;
 			}
 			float GetPercent()
 			{
@@ -454,11 +508,11 @@ namespace olc
 			{
 				return (maxv / 100) * GetPercent();
 			}
-			void UpdateControl() override
+			void UpdateSelf() override
 			{
 				if (orientation == HORIZONTAL)
 				{
-					CBoundingBox* boundingBox = CreateBoundingBox(this->x + headOffset, this->y - 30 / 2, 10, 30);
+					CBox* boundingBox = CreateBox(x + headOffset, y - 30 / 2, 10, 30);
 					if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 					{
 						H_CHover(this);
@@ -479,21 +533,21 @@ namespace olc
 					if (IsSelected)
 					{
 						int newOffset = pge->GetMouseX() - x;
-						if (newOffset >= -1 && newOffset <= (int)this->size + 1)
+						if (newOffset >= -1 && newOffset <= (int)size + 1)
 						{
-							this->headOffset = newOffset;
+							headOffset = newOffset;
 							H_CValueChanged(this, headOffset);
 						}
 					}
-					pge->FillRect(this->x, this->y, this->size, 5, this->backgroundColor);
-					pge->FillRect(this->x + this->headOffset, this->y - 30 / 2, 10, 30, this->foregroundColor);
+					pge->FillRect(x, y, size, 5, backgroundColor);
+					pge->FillRect(x + headOffset, y - 30 / 2, 10, 30, foregroundColor);
 					delete boundingBox;
 					return;
 				}
 
 				if (orientation == VERTICAL)
 				{
-					CBoundingBox* boundingBox = CreateBoundingBox(this->x - 30 / 2, this->y + headOffset, 30, 10);
+					CBox* boundingBox = CreateBox(x - 30 / 2, y + headOffset, 30, 10);
 					if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 					{
 						H_CHover(this);
@@ -514,14 +568,14 @@ namespace olc
 					if (IsSelected)
 					{
 						int newOffset = pge->GetMouseY() - y;
-						if (newOffset >= -1 && newOffset <= (int)this->size + 1)
+						if (newOffset >= -1 && newOffset <= (int)size + 1)
 						{
-							this->headOffset = newOffset;
+							headOffset = newOffset;
 							H_CValueChanged(this, headOffset);
 						}
 					}
-					pge->FillRect(this->x, this->y, 5, this->size, this->backgroundColor);
-					pge->FillRect(this->x - 30 / 2, this->y + headOffset, 30, 10, this->foregroundColor);
+					pge->FillRect(x, y, 5, size, backgroundColor);
+					pge->FillRect(x - 30 / 2, y + headOffset, 30, 10, foregroundColor);
 					delete boundingBox;
 					return;
 				}
@@ -553,16 +607,16 @@ namespace olc
 				this->textScale = textScale;
 			}
 			void PlaceText(float textXOffset, float textYOffset) {
-				this->textXOffset = textXOffset;
-				this->textYOffset = textYOffset;
+				textXOffset = textXOffset;
+				textYOffset = textYOffset;
 			}
 			float GetX() override
 			{
-				return this->x;
+				return x;
 			}
 			float GetY() override
 			{
-				return this->y;
+				return y;
 			}
 			bool IsChecked() {
 				return Checked;
@@ -571,9 +625,9 @@ namespace olc
 			{
 				Checked = !Checked;
 			}
-			void UpdateControl() override
+			void UpdateSelf() override
 			{
-				CBoundingBox* boundingBox = CreateBoundingBox(x, y, 20, 20);
+				CBox* boundingBox = CreateBox(x, y, 20, 20);
 				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY())) {
 					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed) {
 						Checked = !Checked;
@@ -595,9 +649,9 @@ namespace olc
 				}
 
 				if (Checked)
-					pge->DrawString(this->x + 3, this->y + 3, "X", this->selectionColor, 2);
-				pge->DrawRect(this->x, this->y, 20, 20, this->outlineColor);
-				pge->DrawString(this->x + this->textXOffset, this->y + this->textYOffset, this->text, textColor, this->textScale);
+					pge->DrawString(x + 3, y + 3, "X", selectionColor, 2);
+				pge->DrawRect(x, y, 20, 20, outlineColor);
+				pge->DrawString(x + textXOffset, y + textYOffset, text, textColor, textScale);
 				delete boundingBox;
 			}
 		};
@@ -605,7 +659,7 @@ namespace olc
 		/* Similar to a slider but in a circle */
 		class CSpinner : public BasicControl
 		{
-		private:
+		public:
 			olc::Pixel outlineColor;
 			olc::Pixel dotColor;
 			olc::Pixel backgroundColor;
@@ -617,7 +671,6 @@ namespace olc
 			float angle = 0.0f;
 			float radius = 20;
 			int32_t lastValue = 0;
-		public:
 			CSpinner(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dotSize = 0.0f, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel dotColor = olc::Pixel(46, 204, 113), olc::Pixel bgColor = olc::Pixel(0, 0, 0))
 			{
 				this->outlineColor = outlineColor;
@@ -648,13 +701,17 @@ namespace olc
 			{
 				return angle;
 			}
+			void SetAngle(float angle)
+			{
+				angle = angle;
+			}
 			const float MaxAngle()
 			{
 				return 133.0f;
 			}
-			void UpdateControl() override
+			void UpdateSelf() override
 			{
-				CBoundingBox* boundingBox = CreateBoundingBox(x - radius, y - radius, radius * 2, radius * 2);
+				CBox* boundingBox = CreateBox(x - radius, y - radius, radius * 2, radius * 2);
 				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 				{
 					H_CHover(this);

--- a/Extensions/olcPGEX_Controls.h
+++ b/Extensions/olcPGEX_Controls.h
@@ -82,10 +82,9 @@
 
 	What's new?
 	~~~~~~~~~~~
-	  - Now there are frames! And more precisely, child frames.
-	    You can stick any component from olcPGEX_Controls you'd like to.
-	  - There's a new class as well. ComponentPositionController. It's not a controller though.
-	    It's just to store the pointer to the component variable and the offset position
+	  - Slider looks better
+	  - Box is now sensitive to events
+	  - You can draw the box as well if you want to
 */
 
 #ifdef OLC_PGEX_CONTROLS
@@ -294,7 +293,7 @@ namespace olc
 			olc::Pixel foregroundColorHover;
 			std::string text;
 			int32_t textScale;
-			Button(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "Button", int32_t textScale = 2U, olc::Pixel backgroundColor = olc::Pixel(44, 62, 80), olc::Pixel backgroundColorHover = olc::Pixel(52, 73, 94), olc::Pixel foregroundColor = olc::Pixel(236, 240, 241), olc::Pixel foregroundColorHover = olc::Pixel(236, 240, 241))
+			Button(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "Button", int32_t textScale = 2U, olc::Pixel backgroundColor = olc::Pixel(67, 112, 181), olc::Pixel backgroundColorHover = olc::Pixel(19, 52, 105), olc::Pixel foregroundColor = olc::Pixel(236, 240, 241), olc::Pixel foregroundColorHover = olc::Pixel(236, 240, 241))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -359,7 +358,7 @@ namespace olc
 			olc::Pixel backgroundColor;
 			olc::Pixel foregroundColor;
 			Orientation orientation;
-			ProgressBar(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), Orientation orientation = Orientation::HORIZONTAL, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
+			ProgressBar(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), Orientation orientation = Orientation::AUTO, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(67, 112, 181))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -494,7 +493,7 @@ namespace olc
 			olc::Pixel foregroundColor;
 			Orientation orientation;
 			bool IsSelected = false;
-			Slider(olc::vf2d position = olc::vf2d(0.0f, 0.0f), float size = 0.0f, Orientation orientation = AUTO, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
+			Slider(olc::vf2d position = olc::vf2d(0.0f, 0.0f), float size = 0.0f, Orientation orientation = AUTO, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(67, 112, 181))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -684,7 +683,7 @@ namespace olc
 			float angle = 0.0f;
 			float radius = 20;
 			int32_t lastValue = 0;
-			Wheel(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dotSize = 0.0f, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel dotColor = olc::Pixel(46, 204, 113), olc::Pixel bgColor = olc::Pixel(0, 0, 0))
+			Wheel(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dotSize = 0.0f, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel dotColor = olc::Pixel(67, 112, 181), olc::Pixel bgColor = olc::Pixel(0, 0, 0))
 			{
 				this->outlineColor = outlineColor;
 				this->dotColor = dotColor;
@@ -771,7 +770,7 @@ namespace olc
 			bool selected = false;
 			float topBarHeight = 15.0f;
 			std::vector<ComponentPositionController> components;
-			Frame(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), olc::Pixel backgroundColor = olc::Pixel(225, 225, 225), olc::Pixel topBarColor = olc::Pixel(26, 188, 156))
+			Frame(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), olc::Pixel backgroundColor = olc::Pixel(225, 225, 225), olc::Pixel topBarColor = olc::Pixel(67, 112, 181))
 			{
 				this->x = position.x;
 				this->y = position.y;

--- a/Extensions/olcPGEX_Controls.h
+++ b/Extensions/olcPGEX_Controls.h
@@ -1,0 +1,764 @@
+/*
+	olcPGEX_Controls.h
+	+-------------------------------------------------------------+
+	|         OneLoneCoder Pixel Game Engine Extension            |
+	|                        Controls                             |
+	+-------------------------------------------------------------+
+
+	What is this?
+	~~~~~~~~~~~~~
+	This is an extension to the olcPixelGameEngine, which provides
+	basic controls (For now buttons, progress bars and sliders) and event
+	handling.
+	NOTE: This version may still contain some bugs
+
+	Example
+	~~~~~~~
+
+	#define OLC_PGE_APPLICATION
+	#include "olcPixelGameEngine.h"
+
+	#define OLC_PGEX_CONTROLS
+	#include "olcPGEX_Controls.h"
+
+	float r = 0.0f, g = 0.0f, b = 0.0f;
+	class ControlsTest : public olc::PixelGameEngine
+	{
+	public:
+		ControlsTest()
+		{
+		}
+	private:
+		olc::ctrls::CSlider red;
+		olc::ctrls::CSlider green;
+		olc::ctrls::CSlider blue;
+	public:
+
+		bool OnUserCreate() override
+		{
+			olc::ctrls::CSlider red(this, olc::vf2d(200, 200), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
+			this->red = red;
+
+			olc::ctrls::CSlider green(this, olc::vf2d(200, 250), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
+			this->green = green;
+
+			olc::ctrls::CSlider blue(this, olc::vf2d(200, 300), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
+			this->blue = blue;
+			return true;
+		}
+
+		bool OnUserUpdate(float fElapsedTime) override
+		{
+			Clear(olc::BLACK);
+			this->red.UpdateControl();
+			this->green.UpdateControl();
+			this->blue.UpdateControl();
+
+			FillRect(690, 190, 110, 120, olc::Pixel(r, g, b));
+			DrawRect(690, 190, 110, 120, olc::WHITE);
+
+			r = this->red.Value(255);
+			g = this->green.Value(255);
+			b = this->blue.Value(255);
+			return true;
+		}
+	};
+
+	int main()
+	{
+		ControlsTest demo;
+		if (demo.Construct(1100, 500, 1, 1))
+			demo.Start();
+		return 0;
+	}
+*/
+
+#ifdef OLC_PGEX_CONTROLS
+#undef OLC_PGEX_CONTROLS
+
+namespace olc
+{
+	namespace ctrls
+	{
+		const enum Orientation{VERTICAL, HORIZONTAL, AUTO};
+		olc::PixelGameEngine* pge;
+
+		void Init(olc::PixelGameEngine* pxge)
+		{
+			pge = pxge;
+		}
+
+		class BasicControl;
+
+		struct CBoundingBox
+		{
+			int x;
+			int y;
+			int width;
+			int height;
+		};
+
+		CBoundingBox* CreateBoundingBox(int x, int y, int cw, int ch)
+		{
+			return new CBoundingBox{ x, y, cw, ch };
+		}
+
+		/*
+		Handles the events of BasicControls
+		*/
+		class CEventHandler
+		{
+		public:
+			virtual void CClicked(olc::PixelGameEngine* olcpge, BasicControl* cntrl) {} // Evertything
+			virtual void CReleased(olc::PixelGameEngine* olcpge, BasicControl* cntrl) {} // Everything
+			virtual void CHover(olc::PixelGameEngine* olcpge, BasicControl* cntrl) {} // Everything
+			virtual void CValueChanged(olc::PixelGameEngine* olcpge, BasicControl* cntrl, float newValue) {} // Progressbar, Slider
+		};
+
+		/*
+		Basic functions, that every Control needs
+		*/
+		class BasicControl
+		{
+		public:
+			std::vector<CEventHandler*> hndlrs;
+			virtual float GetX()
+			{
+				return 0.0f;
+			}
+
+			virtual float GetY()
+			{
+				return 0.0f;
+			}
+
+			virtual float GetWidth()
+			{
+				return 0.0f;
+			}
+
+			virtual float GetHeight()
+			{
+				return 0.0f;
+			}
+			virtual void UpdateControl()
+			{
+			}
+			void AddEventHandler(CEventHandler* evh)
+			{
+				hndlrs.push_back(evh);
+			}
+			bool IsInBounds(int x, int y, int w, int h, int px, int py)
+			{
+				if (px > x && px <= x + w && py >= y && py <= y + h) {
+					return true;
+				}
+				return false;
+			}
+		};
+
+
+		/*
+		--------------------------------------------------
+		        All controls are registered below
+		--------------------------------------------------
+		*/
+
+		class CButton : public BasicControl
+		{
+		public:
+			float x;
+			float y;
+			float width;
+			float height;
+			float textPosX;
+			float textPosY;
+			olc::Pixel bg_color;
+			olc::Pixel bg_color_hover;
+			olc::Pixel fg_color;
+			olc::Pixel fg_color_hover;
+			std::string text;
+			CButton(olc::vf2d pos = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "CButton", olc::Pixel bg_color = olc::Pixel(44, 62, 80), olc::Pixel bg_color_hover = olc::Pixel(52, 73, 94), olc::Pixel fg_color = olc::Pixel(236, 240, 241), olc::Pixel fg_color_hover = olc::Pixel(236, 240, 241))
+			{
+				this->x = pos.x;
+				this->y = pos.y;
+				this->width = size.x;
+				this->height = size.y;
+				this->bg_color = bg_color;
+				this->bg_color_hover = bg_color_hover;
+				this->fg_color = fg_color;
+				this->fg_color_hover = fg_color_hover;
+				this->text = text;
+				this->textPosX = 0;
+				this->textPosY = 0;
+			}
+			void PlaceText(float tpx, float tpy)
+			{
+				textPosX = tpx;
+				textPosY = tpy;
+			}
+			float GetX() override
+			{
+				return this->x;
+			}
+			float GetY() override
+			{
+				return this->y;
+			}
+			float GetWidth() override
+			{
+				return this->width;
+			}
+			float GetHeight() override
+			{
+				return this->height;
+			}
+			void UpdateControl() override
+			{
+				olc::Pixel* bgc = &bg_color;
+				olc::Pixel* fgc = &fg_color;
+				if (IsInBounds(x, y, width, height, pge->GetMouseX(), pge->GetMouseY())) {
+					bgc = &bg_color_hover;
+					fgc = &fg_color_hover;
+					for (auto& ev : hndlrs)
+					{
+						ev->CHover(pge, this);
+					}
+				}
+				pge->FillRect(x, y, width, height, *bgc);
+				pge->DrawString(x + textPosX, y + textPosY, this->text, *fgc, 2);
+
+				if (IsInBounds(x, y, width, height, pge->GetMouseX(), pge->GetMouseY()))
+				{
+					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
+					{
+						for (auto& ev : hndlrs)
+						{
+							ev->CClicked(pge, this);
+						}
+					}
+					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+					{
+						for (auto& ev : hndlrs)
+						{
+							ev->CReleased(pge, this);
+						}
+					}
+				}
+			}
+		};
+
+		class CProgressBar : public BasicControl
+		{
+		public:
+			float x;
+			float y;
+			float width;
+			float height;
+			float value;
+			olc::Pixel bg_color;
+			olc::Pixel fg_color;
+			Orientation orientation;
+			CProgressBar(olc::vf2d pos = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), Orientation orientation = Orientation::HORIZONTAL, olc::Pixel bg_color = olc::Pixel(88, 92, 92), olc::Pixel fg_color = olc::Pixel(39, 174, 96))
+			{
+				this->x = pos.x;
+				this->y = pos.y;
+				this->width = size.x;
+				this->height = size.y;
+				this->value = 0.0f;
+				this->bg_color = bg_color;
+				this->fg_color = fg_color;
+
+				if (orientation == AUTO)
+					if (width > height)
+						orientation = HORIZONTAL;
+					else if (width < height)
+						orientation = VERTICAL;
+					else
+						orientation = HORIZONTAL;
+
+				this->orientation = orientation;
+			}
+			float GetX() override
+			{
+				return this->x;
+			}
+			float GetY() override
+			{
+				return this->y;
+			}
+			float GetWidth() override
+			{
+				return this->width;
+			}
+			float GetHeight() override
+			{
+				return this->height;
+			}
+			/* Gets the progress size of horizontally oritented progessbar */
+			float GetProgressWidth()
+			{
+				return (this->width / 100) * value;
+			}
+			/* Gets the progress size of vertically oriented progressbar */
+			float GetProgressHeight()
+			{
+				return (this->width / 100) * value;
+			}
+			Orientation GetOrientation()
+			{
+				return this->orientation;
+			}
+			void Increment(float v)
+			{
+				value += v;
+				for (auto& e : hndlrs)
+				{
+					e->CValueChanged(pge, this, value);
+				}
+			}
+			/* Only Increments if value in range */
+			void SafeIncrement(float v)
+			{
+				if (!IsFull())
+					Increment(v);
+			}
+			void Decrement(float v) {
+				this->value -= v;
+				for (auto& e : hndlrs)
+				{
+					e->CValueChanged(pge, this, this->value);
+				}
+			}
+			/* Only Decrements if value in range */
+			void SafeDecrement(float v)
+			{
+				if (!IsEmpty())
+					Decrement(v);
+			}
+
+			void SetValue(float v)
+			{
+				if (v != value)
+				{
+					for (auto& o : hndlrs)
+					{
+						o->CValueChanged(pge, this, v);
+					}
+				}
+				value = v;
+			}
+
+			float GetValue()
+			{
+				return value;
+			}
+
+			bool IsFull()
+			{
+				return value >= 100;
+			}
+			bool IsEmpty()
+			{
+				return value <= 0;
+			}
+			void UpdateControl() override
+			{
+				for (auto& e : hndlrs)
+				{
+					if (IsInBounds(this->x, this->y, this->width, this->height, pge->GetMouseX(), pge->GetMouseY()))
+					{
+						e->CHover(pge, this);
+						if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
+							e->CClicked(pge, this);
+						if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+							e->CReleased(pge, this);
+					}
+				}
+				float nw = this->width;
+				float nh = this->height;
+				switch (orientation)
+				{
+				case HORIZONTAL:
+					nw = (this->width / 100) * this->value;
+						break;
+				case VERTICAL:
+					nh = (this->height / 100) * this->value;
+					break;
+				}
+				pge->FillRect(x, y, this->width, this->height, bg_color);
+				pge->FillRect(x, y, nw, nh, fg_color);
+			}
+		};
+
+		class CSlider : public BasicControl
+		{
+		public:
+			float x;
+			float y;
+			float size;
+			float headOffset;
+			olc::Pixel guide_color;
+			olc::Pixel head_color;
+			Orientation orientation;
+			bool bSelected = false;
+			CSlider(olc::vf2d pos = olc::vf2d(0.0f, 0.0f), float size = 0.0f, Orientation orientation = AUTO, olc::Pixel guide_color = olc::Pixel(88, 92, 92), olc::Pixel head_color = olc::Pixel(39, 174, 96))
+			{
+				this->x = pos.x;
+				this->y = pos.y;
+				this->size = size;
+				this->headOffset = 0;
+				this->guide_color = guide_color;
+				this->head_color = head_color;
+
+				if (orientation == AUTO)
+					orientation = HORIZONTAL;
+
+				this->orientation = orientation;
+			}
+			float GetX() override
+			{
+				return this->x;
+			}
+			float GetY() override
+			{
+				return this->y;
+			}
+			float GetWidth() override
+			{
+				return this->size;
+			}
+			float GetHeight() override
+			{
+				return this->size;
+			}
+			void SetHeadOffset(float hoffset)
+			{
+				this->headOffset = hoffset;
+			}
+			float GetHeadOffset()
+			{
+				return this->headOffset;
+			}
+			float GetPercent()
+			{
+				return headOffset / (size / 100);
+			}
+			float Value(float maxv)
+			{
+				return (maxv / 100) * GetPercent();
+			}
+			void UpdateControl() override
+			{
+				if (orientation == HORIZONTAL)
+				{
+					CBoundingBox* cbb = CreateBoundingBox(this->x + headOffset, this->y - 30/2, 10, 30);
+					if (IsInBounds(cbb->x, cbb->y, cbb->width, cbb->height, pge->GetMouseX(), pge->GetMouseY()))
+					{
+						for (auto& o : hndlrs)
+						{
+							o->CHover(pge, this);
+						}
+						if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
+						{
+							bSelected = true;
+							for (auto& o : hndlrs) {
+								o->CClicked(pge, this);
+							}
+						}
+						if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+						{
+							for (auto& o : hndlrs) {
+								o->CReleased(pge, this);
+							}
+						}
+					}
+					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+					{
+						bSelected = false;
+					}
+					if (bSelected)
+					{
+						int newOffset = pge->GetMouseX() - x;
+						if (newOffset >= -1 && newOffset <= (int)this->size + 1)
+						{
+							this->headOffset = newOffset;
+							for (auto& o : hndlrs)
+							{
+								o->CValueChanged(pge, this, headOffset);
+							}
+						}
+					}
+					pge->FillRect(this->x, this->y, this->size, 5, this->guide_color);
+					pge->FillRect(this->x + this->headOffset, this->y - 30/2, 10, 30, this->head_color);
+					delete cbb;
+					return;
+				}
+
+				if (orientation == VERTICAL)
+				{
+					CBoundingBox* cbb = CreateBoundingBox(this->x - 30/2, this->y + headOffset, 30, 10);
+					if (IsInBounds(cbb->x, cbb->y, cbb->width, cbb->height, pge->GetMouseX(), pge->GetMouseY()))
+					{
+						for (auto& o : hndlrs)
+						{
+							o->CHover(pge, this);
+						}
+						if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
+						{
+							bSelected = true;
+							for (auto& o : hndlrs) {
+								o->CClicked(pge, this);
+							}
+						}
+						if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+						{
+							for (auto& o : hndlrs) {
+								o->CReleased(pge, this);
+							}
+						}
+					}
+					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+					{
+						bSelected = false;
+					}
+					if (bSelected)
+					{
+						int newOffset = pge->GetMouseY() - y;
+						if (newOffset >= -1 && newOffset <= (int)this->size + 1)
+						{
+							this->headOffset = newOffset;
+							for (auto& o : hndlrs)
+							{
+								o->CValueChanged(pge, this, headOffset);
+							}
+						}
+					}
+					pge->FillRect(this->x, this->y, 5, this->size, this->guide_color);
+					pge->FillRect(this->x - 30/2, this->y + headOffset, 30, 10, this->head_color);
+					delete cbb;
+					return;
+				}
+				return;
+			}
+		};
+
+		class CCheckBox : public BasicControl
+		{
+		public:
+			float x;
+			float y;
+			int box_width = 20;
+			int box_height = 20;
+			float txt_x = 0;
+			float txt_y = 0;
+			wint_t txt_scale;
+			std::string text;
+			olc::Pixel box_color;
+			olc::Pixel box_sel;
+			olc::Pixel fg_color;
+			bool bChecked = false;
+			CCheckBox(olc::vf2d pos = olc::vf2d(0, 0), std::string text = "CCheckBox", wint_t txt_scale = 2, olc::Pixel box_color = olc::Pixel(236, 240, 241), olc::Pixel box_sel = olc::Pixel(231, 76, 60), olc::Pixel fg_color = olc::Pixel(236, 240, 241))
+			{
+				this->x = pos.x;
+				this->y = pos.y;
+				this->text = text;
+				this->box_color = box_color;
+				this->box_sel = box_sel;
+				this->fg_color = fg_color;
+				this->txt_scale = txt_scale;
+			}
+			void PlaceText(float txt_x, float txt_y) {
+				this->txt_x = txt_x;
+				this->txt_y = txt_y;
+			}
+			float GetX() override
+			{
+				return this->x;
+			}
+			float GetY() override
+			{
+				return this->y;
+			}
+			float GetWidth() override
+			{
+				return this->box_width;
+			}
+			float GetHeight() override
+			{
+				return this->box_height;
+			}
+			bool IsChecked() {
+				return bChecked;
+			}
+			void Toggle()
+			{
+				bChecked = !bChecked;
+			}
+			void UpdateControl() override
+			{
+				if (IsInBounds(x, y, box_width, box_height, pge->GetMouseX(), pge->GetMouseY())) {
+					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed) {
+						bChecked = !bChecked;
+						float nVal;
+						switch (bChecked) {
+						case true:
+							nVal = 1;
+							break;
+						case false:
+							nVal = 0;
+							break;
+						}
+						for (auto& o : hndlrs) {
+							o->CClicked(pge, this);
+							o->CValueChanged(pge, this, nVal);
+						}
+					}
+					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased) {
+						for (auto& o : hndlrs) {
+							o->CReleased(pge, this);
+						}
+					}
+				}
+
+				if (bChecked)
+					pge->DrawString(this->x+3, this->y+3, "X", this->box_sel, 2);
+				pge->DrawRect(this->x, this->y, this->box_width, this->box_height, this->box_color);
+				pge->DrawString(this->x + this->txt_x, this->y + this->txt_y, this->text, fg_color, this->txt_scale);
+			}
+		};
+
+		/* Similar to a slider but in a circle */
+		class CSpinner : public BasicControl
+		{
+		private:
+			olc::Pixel outline_color;
+			olc::Pixel dot_color;
+			olc::Pixel bg_color;
+			int x;
+			int y;
+			int width;
+			int height;
+			int dot_size;
+			float angle = 0.0f;
+			float radius = 20;
+			int32_t lastValue = 0;
+		public:
+			CSpinner(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dot_size = 0.0f, olc::Pixel outline_color = olc::Pixel(236, 240, 241), olc::Pixel dot_color = olc::Pixel(46, 204, 113), olc::Pixel bg_color = olc::Pixel(0, 0, 0))
+			{
+				this->outline_color = outline_color;
+				this->dot_color = dot_color;
+				this->bg_color = bg_color;
+				this->radius = radius;
+				this->x = position.x;
+				this->y = position.y;
+				this->dot_size = dot_size;
+			}
+			float GetX() override
+			{
+				return x;
+			}
+			float GetY() override
+			{
+				return y;
+			}
+			float GetPercent()
+			{
+				return 100 * (angle / 133.0f) + 0.9;
+			}
+			float Value(float maxv)
+			{
+				return (maxv / 100) * GetPercent();
+			}
+			float GetAngle()
+			{
+				return angle;
+			}
+			const float MaxAngle()
+			{
+				return 133.0f;
+			}
+			void UpdateControl() override
+			{
+				CBoundingBox* cbb = CreateBoundingBox(x - radius, y - radius, radius * 2, radius * 2);
+				if (IsInBounds(cbb->x, cbb->y, cbb->width, cbb->height, pge->GetMouseX(), pge->GetMouseY()))
+				{
+					for (auto& o : hndlrs)
+					{
+						o->CHover(pge, this);
+						if (lastValue != pge->GetMouseWheel())
+						{
+							o->CValueChanged(pge, this, GetPercent());
+						}
+						lastValue = pge->GetMouseWheel();
+					}
+					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
+						for (auto& o : hndlrs)
+						{
+							o->CClicked(pge, this);
+						}
+					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+						for (auto& o : hndlrs)
+						{
+							o->CReleased(pge, this);
+						}
+					angle += (float)pge->GetMouseWheel() / 20;
+				}
+				if ((int)GetPercent() > 100)
+					angle = 0;
+				if (angle < 0)
+					angle = 0;
+				pge->FillCircle(x, y, radius, bg_color);
+				pge->DrawCircle(x, y, radius, outline_color);
+				pge->FillCircle(x + radius / 2 * sin(angle), y + radius / 2 * cos(angle), dot_size, dot_color);
+			}
+		};
+
+		/*
+		--------------------------------------------------
+				All handlers are registered below
+		--------------------------------------------------
+		*/
+
+		/* A CCheckBox pool. Only one CCB can be checked */
+		class CPool_Handler : public CEventHandler
+		{
+		public:
+			std::vector<CCheckBox*> cbx;
+			CPool_Handler(std::vector<CCheckBox*> cbx = {})
+			{
+				this->cbx = cbx;
+			}
+			void AddItem(CCheckBox* cbx)
+			{
+				this->cbx.push_back(cbx);
+			}
+			void SetItems(std::vector<CCheckBox*> cbx)
+			{
+				this->cbx = cbx;
+			}
+			void CValueChanged(olc::PixelGameEngine* pge, BasicControl* ctrl, float nVal) override
+			{
+				for (CCheckBox* cb : cbx)
+				{
+					cb->bChecked = false;
+				}
+				((CCheckBox*)ctrl)->bChecked = true;
+			}
+		};
+
+		/* The easiest way of setting up a CPool_Handler */
+		CPool_Handler* SetupPool(std::vector<CCheckBox*> cbx)
+		{
+			CPool_Handler* pool_h = new CPool_Handler();
+			pool_h->cbx = cbx;
+			for (CCheckBox* cb : cbx)
+			{
+				cb->AddEventHandler(pool_h);
+			}
+			return pool_h;
+		}
+
+	}
+}
+#endif

--- a/Extensions/olcPGEX_Controls.h
+++ b/Extensions/olcPGEX_Controls.h
@@ -82,9 +82,10 @@
 
 	What's new?
 	~~~~~~~~~~~
-	  - Slider looks better
-	  - Box is now sensitive to events
-	  - You can draw the box as well if you want to
+	  - Now there are frames! And more precisely, child frames.
+	    You can stick any component from olcPGEX_Controls you'd like to.
+	  - There's a new class as well. ComponentPositionController. It's not a controller though.
+	    It's just to store the pointer to the component variable and the offset position
 */
 
 #ifdef OLC_PGEX_CONTROLS
@@ -148,6 +149,8 @@ namespace olc
 			std::vector<EventHandler*> eventHandlers;
 			bool lockHandlers = false;
 			bool lockUpdates = false;
+			int x = 0;
+			int y = 0;
 			void LockHandlers()
 			{
 				lockHandlers = true;
@@ -172,14 +175,14 @@ namespace olc
 			{
 				return lockUpdates;
 			}
-			virtual float GetX()
+			float GetX()
 			{
-				return 0.0f;
+				return x;
 			}
 
-			virtual float GetY()
+			float GetY()
 			{
-				return 0.0f;
+				return y;
 			}
 
 			virtual float GetWidth()
@@ -242,13 +245,11 @@ namespace olc
 		class Box : public BaseComponent
 		{
 		public:
-			float x;
-			float y;
 			float width;
 			float height;
 			bool draw;
 			olc::Pixel backgroundColor;
-			Box(float x, float y, float width, float height, bool draw = false, olc::Pixel backgroundColor = olc::Pixel(225, 225, 225))
+			Box(float x = 0.0f, float y = 0.0f, float width = 0.0f, float height = 0.0f, bool draw = false, olc::Pixel backgroundColor = olc::Pixel(225, 225, 225))
 			{
 				this->x = x;
 				this->y = y;
@@ -256,8 +257,6 @@ namespace olc
 				this->height = height;
 				this->backgroundColor = backgroundColor;
 			}
-			float GetX() override { return x; }
-			float GetY() override { return y; }
 			float GetWidth() override { return width; }
 			float GetHeight() override { return height; }
 			bool Contains(float pointX, float pointY)
@@ -285,8 +284,6 @@ namespace olc
 		class Button : public BaseComponent
 		{
 		public:
-			float x;
-			float y;
 			float width;
 			float height;
 			float textXOffset;
@@ -316,14 +313,6 @@ namespace olc
 			{
 				textXOffset = tpx;
 				textYOffset = tpy;
-			}
-			float GetX() override
-			{
-				return x;
-			}
-			float GetY() override
-			{
-				return y;
 			}
 			float GetWidth() override
 			{
@@ -363,8 +352,6 @@ namespace olc
 		class ProgressBar : public BaseComponent
 		{
 		public:
-			float x;
-			float y;
 			float width;
 			float height;
 			float value;
@@ -391,14 +378,6 @@ namespace olc
 						orientation = HORIZONTAL;
 
 				this->orientation = orientation;
-			}
-			float GetX() override
-			{
-				return x;
-			}
-			float GetY() override
-			{
-				return y;
 			}
 			float GetWidth() override
 			{
@@ -509,8 +488,6 @@ namespace olc
 		class Slider : public BaseComponent
 		{
 		public:
-			float x;
-			float y;
 			float size;
 			float headOffset;
 			olc::Pixel backgroundColor;
@@ -530,14 +507,6 @@ namespace olc
 					orientation = HORIZONTAL;
 
 				this->orientation = orientation;
-			}
-			float GetX() override
-			{
-				return x;
-			}
-			float GetY() override
-			{
-				return y;
 			}
 			float GetWidth() override
 			{
@@ -642,8 +611,6 @@ namespace olc
 		class CheckBox : public BaseComponent
 		{
 		public:
-			float x;
-			float y;
 			float textXOffset = 0;
 			float textYOffset = 0;
 			wint_t textScale;
@@ -665,14 +632,6 @@ namespace olc
 			void PlaceText(float textXOffset, float textYOffset) {
 				this->textXOffset = textXOffset;
 				this->textYOffset = textYOffset;
-			}
-			float GetX() override
-			{
-				return x;
-			}
-			float GetY() override
-			{
-				return y;
 			}
 			bool IsChecked() {
 				return Checked;
@@ -719,8 +678,6 @@ namespace olc
 			olc::Pixel outlineColor;
 			olc::Pixel dotColor;
 			olc::Pixel backgroundColor;
-			int x;
-			int y;
 			int width;
 			int height;
 			int dotSize;
@@ -736,14 +693,6 @@ namespace olc
 				this->x = position.x;
 				this->y = position.y;
 				this->dotSize = dotSize;
-			}
-			float GetX() override
-			{
-				return x;
-			}
-			float GetY() override
-			{
-				return y;
 			}
 			float GetPercent()
 			{
@@ -795,6 +744,79 @@ namespace olc
 				pge->FillCircle(x + radius / 2 * sin(angle), y + radius / 2 * cos(angle), dotSize, dotColor);
 				delete boundingBox;
 			}
+		};
+
+		/*
+		Stuff that stores a component pointer and a offset pos 
+		Not really a controller though ...
+		*/
+		class ComponentPositionController
+		{
+		public:
+			BaseComponent* component;
+			olc::vf2d offsetPosition;
+			ComponentPositionController(BaseComponent* component, olc::vf2d offsetPosition)
+			{
+				this->component = component;
+				this->offsetPosition = offsetPosition;
+			}
+		};
+
+		class Frame : public BaseComponent
+		{
+		public:
+			olc::vf2d size;
+			olc::Pixel backgroundColor;
+			olc::Pixel topBarColor;
+			bool selected = false;
+			float topBarHeight = 15.0f;
+			std::vector<ComponentPositionController> components;
+			Frame(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), olc::Pixel backgroundColor = olc::Pixel(225, 225, 225), olc::Pixel topBarColor = olc::Pixel(26, 188, 156))
+			{
+				this->x = position.x;
+				this->y = position.y;
+				this->size = size;
+				this->backgroundColor = backgroundColor;
+				this->topBarColor = topBarColor;
+			}
+			void AddBaseComponent(BaseComponent* basecomp, olc::vf2d offsetPosition = olc::vf2d(0.0f, 0.0f))
+			{
+				this->components.push_back(ComponentPositionController(basecomp, offsetPosition));
+			}
+			void UpdateContents()
+			{
+				for (int i = 0; i < components.size(); i ++)
+				{
+					ComponentPositionController cpc = components[i];
+					BaseComponent* bcomp = cpc.component;
+					bcomp->x = x + cpc.offsetPosition.x;
+					bcomp->y = y + topBarHeight + cpc.offsetPosition.y;
+					cpc.component = bcomp;
+					components[i] = cpc;
+				}
+			}
+			void UpdateSelf() override
+			{
+				Box* boundingBox = new Box(x, y, size.x, topBarHeight);
+				if (pge->GetMouse(0).bPressed)
+				{
+					if (boundingBox->Contains(pge->GetMouseX(), pge->GetMouseY()))
+						selected = true;
+					else
+						selected = false;
+				}
+				if (pge->GetMouse(0).bReleased)
+					selected = false;
+				if (selected)
+				{
+					x = pge->GetMouseX();
+					y = pge->GetMouseY();
+				}
+				pge->FillRect(x, y, size.x, size.y, backgroundColor);
+				pge->FillRect(x, y, size.x, topBarHeight, topBarColor);
+				delete boundingBox;
+			}
+
 		};
 
 		/* A basic checkbox pool */

--- a/Extensions/olcPGEX_Controls.h
+++ b/Extensions/olcPGEX_Controls.h
@@ -29,24 +29,25 @@
 		{
 		}
 	private:
-		olc::ctrls::CSlider red;
-		olc::ctrls::CSlider green;
-		olc::ctrls::CSlider blue;
+		olc::ctrls::Slider red;
+		olc::ctrls::Slider green;
+		olc::ctrls::Slider blue;
 	public:
 
 		bool OnUserCreate() override
 		{
 
-			olc::ctrls::Init(this);
+			olc::ctrls::Initialize(this);
 
-			olc::ctrls::CSlider red(olc::vf2d(200, 200), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
+			olc::ctrls::Slider red(olc::vf2d(200, 200), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
 			this->red = red;
 
-			olc::ctrls::CSlider green(olc::vf2d(200, 250), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
+			olc::ctrls::Slider green(olc::vf2d(200, 250), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
 			this->green = green;
 
-			olc::ctrls::CSlider blue(olc::vf2d(200, 300), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
+			olc::ctrls::Slider blue(olc::vf2d(200, 300), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
 			this->blue = blue;
+
 			return true;
 		}
 
@@ -54,9 +55,9 @@
 		{
 			Clear(olc::BLACK);
 
-			this->red.UpdateControl();
-			this->green.UpdateControl();
-			this->blue.UpdateControl();
+			this->red.Update();
+			this->green.Update();
+			this->blue.Update();
 
 			FillRect(690, 190, 110, 120, olc::Pixel(r, g, b));
 			DrawRect(690, 190, 110, 120, olc::WHITE);
@@ -75,6 +76,12 @@
 			demo.Start();
 		return 0;
 	}
+
+	What's new in 09.05.20
+	~~~~~~~~~~~~~~~~~~~~~~
+	  - Even more names are understandable
+	  - Added the 'AnyEvent' event
+	  - Other stuff.
 */
 
 #ifdef OLC_PGEX_CONTROLS
@@ -82,62 +89,62 @@
 
 namespace olc
 {
+	/* olcPixelGameEngine Controls extension functions & classes */
 	namespace ctrls
 	{
-		const enum Orientation { VERTICAL, HORIZONTAL, AUTO };
+		const enum Orientation
+		{
+			VERTICAL, HORIZONTAL, AUTO
+		};
 
 		olc::PixelGameEngine* pge;
 
-		void Init(olc::PixelGameEngine* pixelGameEngine)
+		void Initialize(olc::PixelGameEngine* pixelGameEngine)
 		{
 			pge = pixelGameEngine;
 		}
 
-		struct CBox
+		struct Box
 		{
 			int x;
 			int y;
 			int width;
 			int height;
+			Box(int x, int y, int width, int height);
+			bool Contains(int pointX, int pointY);
 		};
 
-		CBox* CreateBox(int x, int y, int width, int height)
-		{
-			return new CBox{ x, y, width, height };
+		Box::Box(int x, int y, int width, int height) {
+			this->x = x;
+			this->y = y;
+			this->width = width;
+			this->height = height;
 		}
 
-		bool IsInBounds(CBox* box, int x, int y)
+		bool Box::Contains(int pointX, int pointY)
 		{
-			if (x > box->x && x <= box->x + box->width && y >= box->y && y <= box->y + box->height)
+			if (pointX > x && pointX <= x + width && pointY >= y && pointY <= y + height)
 			{
 				return true;
 			}
 			return false;
 		}
 
-		bool IsInBounds(int boxX, int boxY, int boxWidth, int boxHeight, int pointX, int pointY)
-		{
-			if (pointX > boxX && pointX <= boxX + boxWidth && pointY >= boxY && pointY <= boxY + boxHeight)
-			{
-				return true;
-			}
-			return false;
-		}
-
-		class BasicControl;
-		class CEventHandler
+		class BaseControl;
+		class EventHandler
 		{
 		public:
-			virtual void CClicked(olc::PixelGameEngine* pge, BasicControl* control) {}
-			virtual void CReleased(olc::PixelGameEngine* pge, BasicControl* control) {}
-			virtual void CHover(olc::PixelGameEngine* pge, BasicControl* control) {}
-			virtual void CValueChanged(olc::PixelGameEngine* pge, BasicControl* control, float newValue) {}
+			virtual void MouseClicked(olc::PixelGameEngine* pge, BaseControl* control) {}
+			virtual void MouseReleased(olc::PixelGameEngine* pge, BaseControl* control) {}
+			virtual void MouseHover(olc::PixelGameEngine* pge, BaseControl* control) {}
+			virtual void ValueChanged(olc::PixelGameEngine* pge, BaseControl* control, float newValue) {}
+			virtual void AnyEvent(olc::PixelGameEngine* pge, BaseControl* control) {}
 		};
 
-		class BasicControl
+		class BaseControl
 		{
 		public:
-			std::vector<CEventHandler*> eventHandlers;
+			std::vector<EventHandler*> eventHandlers;
 			bool lockHandlers = false;
 			bool lockUpdates = false;
 			void LockHandlers()
@@ -184,38 +191,50 @@ namespace olc
 				return 0.0f;
 			}
 			virtual void UpdateSelf() {}
-			void UpdateControl()
+			void Update()
 			{
 				if (!lockUpdates)
 					UpdateSelf();
 			}
-			void AddEventHandler(CEventHandler* evh)
+			void AddEventHandler(EventHandler* evh)
 			{
 				this->eventHandlers.push_back(evh);
 			}
-			void H_CClicked(BasicControl* ctrl)
+			void CallMouseClicked(BaseControl* ctrl)
 			{
-				for (CEventHandler* handler : eventHandlers)
-					if (!lockHandlers)
-						handler->CClicked(pge, ctrl);
+				if (!lockHandlers)
+					for (EventHandler* handler : eventHandlers)
+					{
+						handler->MouseClicked(pge, ctrl);
+						handler->AnyEvent(pge, ctrl);
+					}
 			}
-			void H_CReleased(BasicControl* ctrl)
+			void CallMouseReleased(BaseControl* ctrl)
 			{
-				for (CEventHandler* handler : eventHandlers)
-					if (!lockHandlers)
-						handler->CReleased(pge, ctrl);
+				if (!lockHandlers)
+					for (EventHandler* handler : eventHandlers)
+					{
+						handler->MouseReleased(pge, ctrl);
+						handler->AnyEvent(pge, ctrl);
+					}
 			}
-			void H_CHover(BasicControl* ctrl)
+			void CallMouseHover(BaseControl* ctrl)
 			{
-				for (CEventHandler* handler : eventHandlers)
-					if (!lockHandlers)
-						handler->CHover(pge, ctrl);
+				if (!lockHandlers)
+					for (EventHandler* handler : eventHandlers)
+					{
+						handler->MouseHover(pge, ctrl);
+						handler->AnyEvent(pge, ctrl);
+					}
 			}
-			void H_CValueChanged(BasicControl* ctrl, float newValue)
+			void CallValueChanged(BaseControl* ctrl, float newValue)
 			{
-				for (CEventHandler* handler : eventHandlers)
-					if (!lockHandlers)
-						handler->CValueChanged(pge, ctrl, newValue);
+				if (!lockHandlers)
+					for (EventHandler* handler : eventHandlers)
+					{
+						handler->ValueChanged(pge, ctrl, newValue);
+						handler->AnyEvent(pge, ctrl);
+					}
 			}
 		};
 
@@ -225,7 +244,7 @@ namespace olc
 		--------------------------------------------------
 		*/
 
-		class CButton : public BasicControl
+		class Button : public BaseControl
 		{
 		public:
 			float x;
@@ -240,7 +259,7 @@ namespace olc
 			olc::Pixel foregroundColorHover;
 			std::string text;
 			int32_t textScale;
-			CButton(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "CButton", int32_t textScale = 2U, olc::Pixel backgroundColor = olc::Pixel(44, 62, 80), olc::Pixel backgroundColorHover = olc::Pixel(52, 73, 94), olc::Pixel foregroundColor = olc::Pixel(236, 240, 241), olc::Pixel foregroundColorHover = olc::Pixel(236, 240, 241))
+			Button(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "Button", int32_t textScale = 2U, olc::Pixel backgroundColor = olc::Pixel(44, 62, 80), olc::Pixel backgroundColorHover = olc::Pixel(52, 73, 94), olc::Pixel foregroundColor = olc::Pixel(236, 240, 241), olc::Pixel foregroundColorHover = olc::Pixel(236, 240, 241))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -255,10 +274,10 @@ namespace olc
 				this->textYOffset = 0;
 				this->textScale = textScale;
 			}
-			void PlaceText(float textXOffset, float textYOffset)
+			void PlaceText(float tpx, float tpy)
 			{
-				this->textXOffset = textXOffset;
-				this->textYOffset = textYOffset;
+				textXOffset = tpx;
+				textYOffset = tpy;
 			}
 			float GetX() override
 			{
@@ -276,36 +295,34 @@ namespace olc
 			{
 				return height;
 			}
+			float GetTextXOffset()
+			{
+				return this->textXOffset;
+			}
 			void UpdateSelf() override
 			{
 				olc::Pixel backgroundColor = this->backgroundColor;
 				olc::Pixel foregroundColor = this->foregroundColor;
 
-				CBox* boundingBox = CreateBox(x, y, width, height);
-				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY())) {
+				Box* boundingBox = new Box(x, y, width, height);
+
+				if (boundingBox->Contains(pge->GetMouseX(), pge->GetMouseY())) {
+					CallMouseHover(this);
+					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
+						CallMouseClicked(this);
+					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
+						CallMouseReleased(this);
+
 					backgroundColor = backgroundColorHover;
 					foregroundColor = foregroundColorHover;
-					H_CHover(this);
 				}
 				pge->FillRect(x, y, width, height, backgroundColor);
 				pge->DrawString(x + textXOffset, y + textYOffset, text, foregroundColor, textScale);
-
-				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
-				{
-					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
-					{
-						H_CClicked(this);
-					}
-					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
-					{
-						H_CReleased(this);
-					}
-				}
 				delete boundingBox;
 			}
 		};
 
-		class CProgressBar : public BasicControl
+		class ProgressBar : public BaseControl
 		{
 		public:
 			float x;
@@ -313,11 +330,11 @@ namespace olc
 			float width;
 			float height;
 			float value;
-			//float targetValue = 0.0f;
+			float targetValue = 0.0f;
 			olc::Pixel backgroundColor;
 			olc::Pixel foregroundColor;
 			Orientation orientation;
-			CProgressBar(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), Orientation orientation = Orientation::HORIZONTAL, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
+			ProgressBar(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), Orientation orientation = Orientation::HORIZONTAL, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -369,8 +386,8 @@ namespace olc
 			}
 			void Increment(float incrementValue)
 			{
-				value = value + incrementValue;
-				H_CValueChanged(this, value);
+				targetValue = value + incrementValue;
+				CallValueChanged(this, value);
 			}
 			/* Only Increments if value in range */
 			void SafeIncrement(float incrementValue)
@@ -379,8 +396,8 @@ namespace olc
 					Increment(incrementValue);
 			}
 			void Decrement(float decrementValue) {
-				value = value - decrementValue;
-				H_CValueChanged(this, value);
+				targetValue = value - decrementValue;
+				CallValueChanged(this, value);
 			}
 			/* Only Decrements if value in range */
 			void SafeDecrement(float decrementValue)
@@ -392,9 +409,9 @@ namespace olc
 			{
 				if (newValue != value)
 				{
-					H_CValueChanged(this, value);
+					CallValueChanged(this, value);
 				}
-				value = newValue;
+				targetValue = newValue;
 			}
 			float GetValue()
 			{
@@ -410,33 +427,30 @@ namespace olc
 			}
 			void UpdateSelf() override
 			{
-				CBox* boundingBox = CreateBox(x, y, width, height);
-				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
+				Box* boundingBox = new Box(x, y, width, height);
+				if (boundingBox->Contains(pge->GetMouseX(), pge->GetMouseY()))
 				{
-					H_CHover(this);
+					CallMouseHover(this);
 					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
-						H_CClicked(this);
+						CallMouseClicked(this);
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
-						H_CReleased(this);
+						CallMouseReleased(this);
 				}
 
 				// Smooth progress bars
-				/*if ((int)value != (int)targetValue)
+				if ((int)value != (int)targetValue)
 				{
 					if ((int)targetValue < (int)value)
 					{
-						if (value+1 >= 0)
-							value -= 0.2f;
-						else
-							if (value > targetValue)
-								value = 0;
+						if (!IsEmpty())
+							value -= 0.4f;
 					}
 					else if ((int)targetValue > (int)value)
 					{
-						if (value <= 100)
+						if (!IsFull())
 							value += 0.4f;
 					}
-				}*/
+				}
 				float newWidth = width;
 				float newHeight = height;
 				switch (orientation)
@@ -454,7 +468,7 @@ namespace olc
 			}
 		};
 
-		class CSlider : public BasicControl
+		class Slider : public BaseControl
 		{
 		public:
 			float x;
@@ -465,7 +479,7 @@ namespace olc
 			olc::Pixel foregroundColor;
 			Orientation orientation;
 			bool IsSelected = false;
-			CSlider(olc::vf2d position = olc::vf2d(0.0f, 0.0f), float size = 0.0f, Orientation orientation = AUTO, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
+			Slider(olc::vf2d position = olc::vf2d(0.0f, 0.0f), float size = 0.0f, Orientation orientation = AUTO, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -515,18 +529,18 @@ namespace olc
 			{
 				if (orientation == HORIZONTAL)
 				{
-					CBox* boundingBox = CreateBox(x + headOffset, y - 30 / 2, 10, 30);
-					if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
+					Box* boundingBox = new Box(x + headOffset, y - 30 / 2, 10, 30);
+					if (boundingBox->Contains(pge->GetMouseX(), pge->GetMouseY()))
 					{
-						H_CHover(this);
+						CallMouseHover(this);
 						if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
 						{
 							IsSelected = true;
-							H_CClicked(this);
+							CallMouseClicked(this);
 						}
 						if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
 						{
-							H_CReleased(this);
+							CallMouseReleased(this);
 						}
 					}
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
@@ -539,7 +553,7 @@ namespace olc
 						if (newOffset >= -1 && newOffset <= (int)size + 1)
 						{
 							headOffset = newOffset;
-							H_CValueChanged(this, headOffset);
+							CallValueChanged(this, headOffset);
 						}
 					}
 					pge->FillRect(x, y, size, 5, backgroundColor);
@@ -550,18 +564,18 @@ namespace olc
 
 				if (orientation == VERTICAL)
 				{
-					CBox* boundingBox = CreateBox(x - 30 / 2, y + headOffset, 30, 10);
-					if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
+					Box* boundingBox = new Box(x - 30 / 2, y + headOffset, 30, 10);
+					if (boundingBox->Contains(pge->GetMouseX(), pge->GetMouseY()))
 					{
-						H_CHover(this);
+						CallMouseHover(this);
 						if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
 						{
 							IsSelected = true;
-							H_CClicked(this);
+							CallMouseClicked(this);
 						}
 						if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
 						{
-							H_CReleased(this);
+							CallMouseReleased(this);
 						}
 					}
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
@@ -574,7 +588,7 @@ namespace olc
 						if (newOffset >= -1 && newOffset <= (int)size + 1)
 						{
 							headOffset = newOffset;
-							H_CValueChanged(this, headOffset);
+							CallValueChanged(this, headOffset);
 						}
 					}
 					pge->FillRect(x, y, 5, size, backgroundColor);
@@ -586,7 +600,7 @@ namespace olc
 			}
 		};
 
-		class CCheckBox : public BasicControl
+		class CheckBox : public BaseControl
 		{
 		public:
 			float x;
@@ -599,7 +613,7 @@ namespace olc
 			olc::Pixel selectionColor;
 			olc::Pixel textColor;
 			bool Checked = false;
-			CCheckBox(olc::vf2d position = olc::vf2d(0, 0), std::string text = "CCheckBox", wint_t textScale = 2, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel selectionColor = olc::Pixel(231, 76, 60), olc::Pixel textColor = olc::Pixel(236, 240, 241))
+			CheckBox(olc::vf2d position = olc::vf2d(0, 0), std::string text = "CheckBox", wint_t textScale = 2, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel selectionColor = olc::Pixel(231, 76, 60), olc::Pixel textColor = olc::Pixel(236, 240, 241))
 			{
 				this->x = position.x;
 				this->y = position.y;
@@ -630,8 +644,8 @@ namespace olc
 			}
 			void UpdateSelf() override
 			{
-				CBox* boundingBox = CreateBox(x, y, 20, 20);
-				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY())) {
+				Box* boundingBox = new Box(x, y, 20, 20);
+				if (boundingBox->Contains(pge->GetMouseX(), pge->GetMouseY())) {
 					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed) {
 						Checked = !Checked;
 						float newValue;
@@ -643,11 +657,11 @@ namespace olc
 							newValue = 0;
 							break;
 						}
-						H_CClicked(this);
-						H_CValueChanged(this, newValue);
+						CallMouseClicked(this);
+						CallValueChanged(this, newValue);
 					}
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased) {
-						H_CReleased(this);
+						CallMouseReleased(this);
 					}
 				}
 
@@ -660,7 +674,7 @@ namespace olc
 		};
 
 		/* Similar to a slider but in a circle */
-		class CSpinner : public BasicControl
+		class Wheel : public BaseControl
 		{
 		public:
 			olc::Pixel outlineColor;
@@ -674,7 +688,7 @@ namespace olc
 			float angle = 0.0f;
 			float radius = 20;
 			int32_t lastValue = 0;
-			CSpinner(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dotSize = 0.0f, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel dotColor = olc::Pixel(46, 204, 113), olc::Pixel bgColor = olc::Pixel(0, 0, 0))
+			Wheel(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dotSize = 0.0f, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel dotColor = olc::Pixel(46, 204, 113), olc::Pixel bgColor = olc::Pixel(0, 0, 0))
 			{
 				this->outlineColor = outlineColor;
 				this->dotColor = dotColor;
@@ -714,22 +728,22 @@ namespace olc
 			}
 			void UpdateSelf() override
 			{
-				CBox* boundingBox = CreateBox(x - radius, y - radius, radius * 2, radius * 2);
-				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
+				Box* boundingBox = new Box(x - radius, y - radius, radius * 2, radius * 2);
+				if (boundingBox->Contains(pge->GetMouseX(), pge->GetMouseY()))
 				{
-					H_CHover(this);
+					CallMouseHover(this);
 					if (lastValue != pge->GetMouseWheel())
 					{
-						H_CValueChanged(this, GetPercent());
+						CallValueChanged(this, GetPercent());
 					}
 					lastValue = pge->GetMouseWheel();
 					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
 					{
-						H_CClicked(this);
+						CallMouseClicked(this);
 					}
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
 					{
-						H_CReleased(this);
+						CallMouseReleased(this);
 					}
 					angle += (float)pge->GetMouseWheel() / 20;
 				}
@@ -744,49 +758,44 @@ namespace olc
 			}
 		};
 
-		/*
-		--------------------------------------------------
-				All handlers are registered below
-		--------------------------------------------------
-		*/
 
 		/* A basic checkbox pool */
-		class CPool_Handler : public CEventHandler
+		class CheckBoxPool : public EventHandler
 		{
 		public:
-			std::vector<CCheckBox*> checkboxVector;
-			CPool_Handler(std::vector<CCheckBox*> checkboxVector = {})
+			std::vector<CheckBox*> checkboxVector;
+			CheckBoxPool(std::vector<CheckBox*> checkboxVector = {})
 			{
 				this->checkboxVector = checkboxVector;
 			}
-			void AddItem(CCheckBox* checkbox)
+			void AddItem(CheckBox* checkbox)
 			{
 				this->checkboxVector.push_back(checkbox);
 			}
-			void SetItems(std::vector<CCheckBox*> checkboxVector)
+			void SetItems(std::vector<CheckBox*> checkboxVector)
 			{
 				this->checkboxVector = checkboxVector;
 			}
-			void CValueChanged(olc::PixelGameEngine* pge, BasicControl* ctrl, float nVal) override
+			void ValueChanged(olc::PixelGameEngine* pge, BaseControl* ctrl, float nVal) override
 			{
-				for (CCheckBox* cb : checkboxVector)
+				for (CheckBox* cb : checkboxVector)
 				{
 					cb->Checked = false;
 				}
-				((CCheckBox*)ctrl)->Checked = true;
+				((CheckBox*)ctrl)->Checked = true;
 			}
 		};
 
 		/* The easiest way of setting up a CPool_Handler */
-		CPool_Handler* SetupPool(std::vector<CCheckBox*> checkboxVector)
+		CheckBoxPool* SetupPool(std::vector<CheckBox*> checkboxVector)
 		{
-			CPool_Handler* poolHandler = new CPool_Handler();
-			poolHandler->checkboxVector = checkboxVector;
-			for (CCheckBox* cb : checkboxVector)
+			CheckBoxPool* checkBoxPool = new CheckBoxPool();
+			checkBoxPool->checkboxVector = checkboxVector;
+			for (CheckBox* cb : checkboxVector)
 			{
-				cb->AddEventHandler(poolHandler);
+				cb->AddEventHandler(checkBoxPool);
 			}
-			return poolHandler;
+			return checkBoxPool;
 		}
 
 	}

--- a/Extensions/olcPGEX_Controls.h
+++ b/Extensions/olcPGEX_Controls.h
@@ -4,7 +4,7 @@
 	|         OneLoneCoder Pixel Game Engine Extension            |
 	|                       Controls                              |
 	+-------------------------------------------------------------+
-	
+
 	What is this?
 	~~~~~~~~~~~~~
 	This is an extension to the olcPixelGameEngine, which provides
@@ -20,7 +20,9 @@
 	#define OLC_PGEX_CONTROLS
 	#include "olcPGEX_Controls.h"
 
-	float r = 0.0f, g = 0.0f, b = 0.0f;
+	float r = 0.0f;
+	float g = 0.0f;
+	float b = 0.0f;
 	class ControlsTest : public olc::PixelGameEngine
 	{
 	public:
@@ -35,9 +37,9 @@
 
 		bool OnUserCreate() override
 		{
-		
+
 			olc::ctrls::Init(this);
-			
+
 			olc::ctrls::CSlider red(olc::vf2d(200, 200), 300, olc::ctrls::HORIZONTAL, olc::GREY, olc::GREEN);
 			this->red = red;
 
@@ -52,6 +54,7 @@
 		bool OnUserUpdate(float fElapsedTime) override
 		{
 			Clear(olc::BLACK);
+
 			this->red.UpdateControl();
 			this->green.UpdateControl();
 			this->blue.UpdateControl();
@@ -82,12 +85,13 @@ namespace olc
 {
 	namespace ctrls
 	{
-		const enum Orientation{VERTICAL, HORIZONTAL, AUTO};
+		const enum Orientation { VERTICAL, HORIZONTAL, AUTO };
+
 		olc::PixelGameEngine* pge;
 
-		void Init(olc::PixelGameEngine* pxge)
+		void Init(olc::PixelGameEngine* pixelGameEngine)
 		{
-			pge = pxge;
+			pge = pixelGameEngine;
 		}
 
 		class BasicControl;
@@ -100,9 +104,9 @@ namespace olc
 			int height;
 		};
 
-		CBoundingBox* CreateBoundingBox(int x, int y, int cw, int ch)
+		CBoundingBox* CreateBoundingBox(int x, int y, int width, int height)
 		{
-			return new CBoundingBox{ x, y, cw, ch };
+			return new CBoundingBox{ x, y, width, height };
 		}
 
 		/*
@@ -111,19 +115,16 @@ namespace olc
 		class CEventHandler
 		{
 		public:
-			virtual void CClicked(olc::PixelGameEngine* olcpge, BasicControl* cntrl) {} // Evertything
-			virtual void CReleased(olc::PixelGameEngine* olcpge, BasicControl* cntrl) {} // Everything
-			virtual void CHover(olc::PixelGameEngine* olcpge, BasicControl* cntrl) {} // Everything
-			virtual void CValueChanged(olc::PixelGameEngine* olcpge, BasicControl* cntrl, float newValue) {} // Progressbar, Slider
+			virtual void CClicked(olc::PixelGameEngine* pge, BasicControl* control) {}
+			virtual void CReleased(olc::PixelGameEngine* pge, BasicControl* control) {}
+			virtual void CHover(olc::PixelGameEngine* pge, BasicControl* control) {}
+			virtual void CValueChanged(olc::PixelGameEngine* pge, BasicControl* control, float newValue) {}
 		};
 
-		/*
-		Basic functions, that every Control needs
-		*/
 		class BasicControl
 		{
 		public:
-			std::vector<CEventHandler*> hndlrs;
+			std::vector<CEventHandler*> eventHandlers;
 			virtual float GetX()
 			{
 				return 0.0f;
@@ -143,38 +144,40 @@ namespace olc
 			{
 				return 0.0f;
 			}
-			virtual void UpdateControl()
-			{
-			}
+			virtual void UpdateControl() {}
 			void AddEventHandler(CEventHandler* evh)
 			{
-				hndlrs.push_back(evh);
+				eventHandlers.push_back(evh);
 			}
-			bool IsInBounds(int x, int y, int w, int h, int px, int py)
+			bool IsInBounds(int x, int y, int w, int h, int pointX, int pointY)
 			{
-				if (px > x && px <= x + w && py >= y && py <= y + h) {
+				if (pointX > x && pointX <= x + w && pointY >= y && pointY <= y + h) {
 					return true;
 				}
 				return false;
 			}
+			bool IsInBounds(CBoundingBox* boundingBox, int pointX, int pointY)
+			{
+				return IsInBounds(boundingBox->x, boundingBox->y, boundingBox->width, boundingBox->height, pointX, pointY);
+			}
 			void H_CClicked(BasicControl* ctrl)
 			{
-				for (CEventHandler* handler : hndlrs)
+				for (CEventHandler* handler : eventHandlers)
 					handler->CClicked(pge, ctrl);
 			}
 			void H_CReleased(BasicControl* ctrl)
 			{
-				for (CEventHandler* handler : hndlrs)
+				for (CEventHandler* handler : eventHandlers)
 					handler->CReleased(pge, ctrl);
 			}
 			void H_CHover(BasicControl* ctrl)
 			{
-				for (CEventHandler* handler : hndlrs)
+				for (CEventHandler* handler : eventHandlers)
 					handler->CHover(pge, ctrl);
 			}
 			void H_CValueChanged(BasicControl* ctrl, float newValue)
 			{
-				for (CEventHandler* handler : hndlrs)
+				for (CEventHandler* handler : eventHandlers)
 					handler->CValueChanged(pge, ctrl, newValue);
 			}
 		};
@@ -182,7 +185,7 @@ namespace olc
 
 		/*
 		--------------------------------------------------
-		        All controls are registered below
+				All controls are registered below
 		--------------------------------------------------
 		*/
 
@@ -193,31 +196,31 @@ namespace olc
 			float y;
 			float width;
 			float height;
-			float textPosX;
-			float textPosY;
-			olc::Pixel bg_color;
-			olc::Pixel bg_color_hover;
-			olc::Pixel fg_color;
-			olc::Pixel fg_color_hover;
+			float textXOffset;
+			float textYOffset;
+			olc::Pixel backgroundColor;
+			olc::Pixel backgroundColorHover;
+			olc::Pixel foregroundColor;
+			olc::Pixel foregroundColorHover;
 			std::string text;
-			CButton(olc::vf2d pos = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "CButton", olc::Pixel bg_color = olc::Pixel(44, 62, 80), olc::Pixel bg_color_hover = olc::Pixel(52, 73, 94), olc::Pixel fg_color = olc::Pixel(236, 240, 241), olc::Pixel fg_color_hover = olc::Pixel(236, 240, 241))
+			CButton(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), std::string text = "CButton", olc::Pixel backgroundColor = olc::Pixel(44, 62, 80), olc::Pixel backgroundColorHover = olc::Pixel(52, 73, 94), olc::Pixel foregroundColor = olc::Pixel(236, 240, 241), olc::Pixel foregroundColorHover = olc::Pixel(236, 240, 241))
 			{
-				this->x = pos.x;
-				this->y = pos.y;
+				this->x = position.x;
+				this->y = position.y;
 				this->width = size.x;
 				this->height = size.y;
-				this->bg_color = bg_color;
-				this->bg_color_hover = bg_color_hover;
-				this->fg_color = fg_color;
-				this->fg_color_hover = fg_color_hover;
+				this->backgroundColor = backgroundColor;
+				this->backgroundColorHover = backgroundColorHover;
+				this->foregroundColor = foregroundColor;
+				this->foregroundColorHover = foregroundColorHover;
 				this->text = text;
-				this->textPosX = 0;
-				this->textPosY = 0;
+				this->textXOffset = 0;
+				this->textYOffset = 0;
 			}
 			void PlaceText(float tpx, float tpy)
 			{
-				textPosX = tpx;
-				textPosY = tpy;
+				textXOffset = tpx;
+				textYOffset = tpy;
 			}
 			float GetX() override
 			{
@@ -237,15 +240,17 @@ namespace olc
 			}
 			void UpdateControl() override
 			{
-				olc::Pixel* bgc = &bg_color;
-				olc::Pixel* fgc = &fg_color;
-				if (IsInBounds(x, y, width, height, pge->GetMouseX(), pge->GetMouseY())) {
-					bgc = &bg_color_hover;
-					fgc = &fg_color_hover;
+				olc::Pixel backgroundColor = this->backgroundColor;
+				olc::Pixel foregroundColor = this->foregroundColor;
+
+				CBoundingBox* boundingBox = CreateBoundingBox(x, y, width, height);
+				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY())) {
+					backgroundColor = this->backgroundColorHover;
+					foregroundColor = this->foregroundColorHover;
 					H_CHover(this);
 				}
-				pge->FillRect(x, y, width, height, *bgc);
-				pge->DrawString(x + textPosX, y + textPosY, this->text, *fgc, 2);
+				pge->FillRect(x, y, width, height, backgroundColor);
+				pge->DrawString(x + textXOffset, y + textYOffset, this->text, foregroundColor, 2);
 
 				if (IsInBounds(x, y, width, height, pge->GetMouseX(), pge->GetMouseY()))
 				{
@@ -258,6 +263,7 @@ namespace olc
 						H_CReleased(this);
 					}
 				}
+				delete boundingBox;
 			}
 		};
 
@@ -269,18 +275,18 @@ namespace olc
 			float width;
 			float height;
 			float value;
-			olc::Pixel bg_color;
-			olc::Pixel fg_color;
+			olc::Pixel backgroundColor;
+			olc::Pixel foregroundColor;
 			Orientation orientation;
-			CProgressBar(olc::vf2d pos = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), Orientation orientation = Orientation::HORIZONTAL, olc::Pixel bg_color = olc::Pixel(88, 92, 92), olc::Pixel fg_color = olc::Pixel(39, 174, 96))
+			CProgressBar(olc::vf2d position = olc::vf2d(0.0f, 0.0f), olc::vf2d size = olc::vf2d(0.0f, 0.0f), Orientation orientation = Orientation::HORIZONTAL, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
 			{
-				this->x = pos.x;
-				this->y = pos.y;
+				this->x = position.x;
+				this->y = position.y;
 				this->width = size.x;
 				this->height = size.y;
 				this->value = 0.0f;
-				this->bg_color = bg_color;
-				this->fg_color = fg_color;
+				this->backgroundColor = backgroundColor;
+				this->foregroundColor = foregroundColor;
 
 				if (orientation == AUTO)
 					if (width > height)
@@ -308,12 +314,12 @@ namespace olc
 			{
 				return this->height;
 			}
-			/* Gets the progress size of horizontally oritented progessbar */
+			/* Gets the progress size of horizontal progressbar */
 			float GetProgressWidth()
 			{
 				return (this->width / 100) * value;
 			}
-			/* Gets the progress size of vertically oriented progressbar */
+			/* Gets the progress size of vertical progressbar */
 			float GetProgressHeight()
 			{
 				return (this->width / 100) * value;
@@ -322,42 +328,39 @@ namespace olc
 			{
 				return this->orientation;
 			}
-			void Increment(float v)
+			void Increment(float incrementValue)
 			{
-				value += v;
-				H_CValueChanged(this, v);
+				value += incrementValue;
+				H_CValueChanged(this, value);
 			}
 			/* Only Increments if value in range */
-			void SafeIncrement(float v)
+			void SafeIncrement(float incrementValue)
 			{
 				if (!IsFull())
-					Increment(v);
+					Increment(incrementValue);
 			}
-			void Decrement(float v) {
-				this->value -= v;
-				H_CValueChanged(this, v);
+			void Decrement(float decrementValue) {
+				this->value -= decrementValue;
+				H_CValueChanged(this, value);
 			}
 			/* Only Decrements if value in range */
-			void SafeDecrement(float v)
+			void SafeDecrement(float decrementValue)
 			{
 				if (!IsEmpty())
-					Decrement(v);
+					Decrement(decrementValue);
 			}
-
-			void SetValue(float v)
+			void SetValue(float newValue)
 			{
-				if (v != value)
+				if (newValue != value)
 				{
-					H_CValueChanged(this, v);
+					H_CValueChanged(this, value);
 				}
-				value = v;
+				value = newValue;
 			}
-
 			float GetValue()
 			{
 				return value;
 			}
-
 			bool IsFull()
 			{
 				return value >= 100;
@@ -368,7 +371,8 @@ namespace olc
 			}
 			void UpdateControl() override
 			{
-				if (IsInBounds(this->x, this->y, this->width, this->height, pge->GetMouseX(), pge->GetMouseY()))
+				CBoundingBox* boundingBox = CreateBoundingBox(x, y, width, height);
+				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 				{
 					H_CHover(this);
 					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
@@ -376,19 +380,20 @@ namespace olc
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
 						H_CReleased(this);
 				}
-				float nw = this->width;
-				float nh = this->height;
+				float newWidth = this->width;
+				float newHeight = this->height;
 				switch (orientation)
 				{
 				case HORIZONTAL:
-					nw = (this->width / 100) * this->value;
-						break;
+					newWidth = (this->width / 100) * this->value;
+					break;
 				case VERTICAL:
-					nh = (this->height / 100) * this->value;
+					newHeight = (this->height / 100) * this->value;
 					break;
 				}
-				pge->FillRect(x, y, this->width, this->height, bg_color);
-				pge->FillRect(x, y, nw, nh, fg_color);
+				pge->FillRect(x, y, this->width, this->height, backgroundColor);
+				pge->FillRect(x, y, newWidth, newHeight, foregroundColor);
+				delete boundingBox;
 			}
 		};
 
@@ -399,18 +404,18 @@ namespace olc
 			float y;
 			float size;
 			float headOffset;
-			olc::Pixel guide_color;
-			olc::Pixel head_color;
+			olc::Pixel backgroundColor;
+			olc::Pixel foregroundColor;
 			Orientation orientation;
-			bool bSelected = false;
-			CSlider(olc::vf2d pos = olc::vf2d(0.0f, 0.0f), float size = 0.0f, Orientation orientation = AUTO, olc::Pixel guide_color = olc::Pixel(88, 92, 92), olc::Pixel head_color = olc::Pixel(39, 174, 96))
+			bool IsSelected = false;
+			CSlider(olc::vf2d position = olc::vf2d(0.0f, 0.0f), float size = 0.0f, Orientation orientation = AUTO, olc::Pixel backgroundColor = olc::Pixel(88, 92, 92), olc::Pixel foregroundColor = olc::Pixel(39, 174, 96))
 			{
-				this->x = pos.x;
-				this->y = pos.y;
+				this->x = position.x;
+				this->y = position.y;
 				this->size = size;
 				this->headOffset = 0;
-				this->guide_color = guide_color;
-				this->head_color = head_color;
+				this->backgroundColor = backgroundColor;
+				this->foregroundColor = foregroundColor;
 
 				if (orientation == AUTO)
 					orientation = HORIZONTAL;
@@ -453,13 +458,13 @@ namespace olc
 			{
 				if (orientation == HORIZONTAL)
 				{
-					CBoundingBox* cbb = CreateBoundingBox(this->x + headOffset, this->y - 30/2, 10, 30);
-					if (IsInBounds(cbb->x, cbb->y, cbb->width, cbb->height, pge->GetMouseX(), pge->GetMouseY()))
+					CBoundingBox* boundingBox = CreateBoundingBox(this->x + headOffset, this->y - 30 / 2, 10, 30);
+					if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 					{
 						H_CHover(this);
 						if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
 						{
-							bSelected = true;
+							IsSelected = true;
 							H_CClicked(this);
 						}
 						if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
@@ -469,9 +474,9 @@ namespace olc
 					}
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
 					{
-						bSelected = false;
+						IsSelected = false;
 					}
-					if (bSelected)
+					if (IsSelected)
 					{
 						int newOffset = pge->GetMouseX() - x;
 						if (newOffset >= -1 && newOffset <= (int)this->size + 1)
@@ -480,21 +485,21 @@ namespace olc
 							H_CValueChanged(this, headOffset);
 						}
 					}
-					pge->FillRect(this->x, this->y, this->size, 5, this->guide_color);
-					pge->FillRect(this->x + this->headOffset, this->y - 30/2, 10, 30, this->head_color);
-					delete cbb;
+					pge->FillRect(this->x, this->y, this->size, 5, this->backgroundColor);
+					pge->FillRect(this->x + this->headOffset, this->y - 30 / 2, 10, 30, this->foregroundColor);
+					delete boundingBox;
 					return;
 				}
 
 				if (orientation == VERTICAL)
 				{
-					CBoundingBox* cbb = CreateBoundingBox(this->x - 30/2, this->y + headOffset, 30, 10);
-					if (IsInBounds(cbb->x, cbb->y, cbb->width, cbb->height, pge->GetMouseX(), pge->GetMouseY()))
+					CBoundingBox* boundingBox = CreateBoundingBox(this->x - 30 / 2, this->y + headOffset, 30, 10);
+					if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 					{
 						H_CHover(this);
 						if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed)
 						{
-							bSelected = true;
+							IsSelected = true;
 							H_CClicked(this);
 						}
 						if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
@@ -504,9 +509,9 @@ namespace olc
 					}
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased)
 					{
-						bSelected = false;
+						IsSelected = false;
 					}
-					if (bSelected)
+					if (IsSelected)
 					{
 						int newOffset = pge->GetMouseY() - y;
 						if (newOffset >= -1 && newOffset <= (int)this->size + 1)
@@ -515,9 +520,9 @@ namespace olc
 							H_CValueChanged(this, headOffset);
 						}
 					}
-					pge->FillRect(this->x, this->y, 5, this->size, this->guide_color);
-					pge->FillRect(this->x - 30/2, this->y + headOffset, 30, 10, this->head_color);
-					delete cbb;
+					pge->FillRect(this->x, this->y, 5, this->size, this->backgroundColor);
+					pge->FillRect(this->x - 30 / 2, this->y + headOffset, 30, 10, this->foregroundColor);
+					delete boundingBox;
 					return;
 				}
 				return;
@@ -529,29 +534,27 @@ namespace olc
 		public:
 			float x;
 			float y;
-			int box_width = 20;
-			int box_height = 20;
-			float txt_x = 0;
-			float txt_y = 0;
-			wint_t txt_scale;
+			float textXOffset = 0;
+			float textYOffset = 0;
+			wint_t textScale;
 			std::string text;
-			olc::Pixel box_color;
-			olc::Pixel box_sel;
-			olc::Pixel fg_color;
-			bool bChecked = false;
-			CCheckBox(olc::vf2d pos = olc::vf2d(0, 0), std::string text = "CCheckBox", wint_t txt_scale = 2, olc::Pixel box_color = olc::Pixel(236, 240, 241), olc::Pixel box_sel = olc::Pixel(231, 76, 60), olc::Pixel fg_color = olc::Pixel(236, 240, 241))
+			olc::Pixel outlineColor;
+			olc::Pixel selectionColor;
+			olc::Pixel textColor;
+			bool Checked = false;
+			CCheckBox(olc::vf2d position = olc::vf2d(0, 0), std::string text = "CCheckBox", wint_t textScale = 2, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel selectionColor = olc::Pixel(231, 76, 60), olc::Pixel textColor = olc::Pixel(236, 240, 241))
 			{
-				this->x = pos.x;
-				this->y = pos.y;
+				this->x = position.x;
+				this->y = position.y;
 				this->text = text;
-				this->box_color = box_color;
-				this->box_sel = box_sel;
-				this->fg_color = fg_color;
-				this->txt_scale = txt_scale;
+				this->outlineColor = outlineColor;
+				this->selectionColor = selectionColor;
+				this->textColor = textColor;
+				this->textScale = textScale;
 			}
-			void PlaceText(float txt_x, float txt_y) {
-				this->txt_x = txt_x;
-				this->txt_y = txt_y;
+			void PlaceText(float textXOffset, float textYOffset) {
+				this->textXOffset = textXOffset;
+				this->textYOffset = textYOffset;
 			}
 			float GetX() override
 			{
@@ -561,47 +564,41 @@ namespace olc
 			{
 				return this->y;
 			}
-			float GetWidth() override
-			{
-				return this->box_width;
-			}
-			float GetHeight() override
-			{
-				return this->box_height;
-			}
 			bool IsChecked() {
-				return bChecked;
+				return Checked;
 			}
 			void Toggle()
 			{
-				bChecked = !bChecked;
+				Checked = !Checked;
 			}
 			void UpdateControl() override
 			{
-				if (IsInBounds(x, y, box_width, box_height, pge->GetMouseX(), pge->GetMouseY())) {
+				CBoundingBox* boundingBox = CreateBoundingBox(x, y, 20, 20);
+				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY())) {
 					if (pge->GetMouse(0).bPressed || pge->GetMouse(1).bPressed || pge->GetMouse(2).bPressed) {
-						bChecked = !bChecked;
-						float nVal;
-						switch (bChecked) {
+						Checked = !Checked;
+						float newValue;
+						switch (Checked) {
 						case true:
-							nVal = 1;
+							newValue = 1;
 							break;
 						case false:
-							nVal = 0;
+							newValue = 0;
 							break;
 						}
 						H_CClicked(this);
-						H_CValueChanged(this, nVal);
+						H_CValueChanged(this, newValue);
 					}
 					if (pge->GetMouse(0).bReleased || pge->GetMouse(1).bReleased || pge->GetMouse(2).bReleased) {
 						H_CReleased(this);
 					}
 				}
 
-				if (bChecked)
-					pge->DrawString(this->x+3, this->y+3, "X", this->box_sel, 2);
-				pge->DrawRect(this->x, this->y, this->box_width, this->box_height, this->box_color);
-				pge->DrawString(this->x + this->txt_x, this->y + this->txt_y, this->text, fg_color, this->txt_scale);
+				if (Checked)
+					pge->DrawString(this->x + 3, this->y + 3, "X", this->selectionColor, 2);
+				pge->DrawRect(this->x, this->y, 20, 20, this->outlineColor);
+				pge->DrawString(this->x + this->textXOffset, this->y + this->textYOffset, this->text, textColor, this->textScale);
+				delete boundingBox;
 			}
 		};
 
@@ -609,27 +606,27 @@ namespace olc
 		class CSpinner : public BasicControl
 		{
 		private:
-			olc::Pixel outline_color;
-			olc::Pixel dot_color;
-			olc::Pixel bg_color;
+			olc::Pixel outlineColor;
+			olc::Pixel dotColor;
+			olc::Pixel backgroundColor;
 			int x;
 			int y;
 			int width;
 			int height;
-			int dot_size;
+			int dotSize;
 			float angle = 0.0f;
 			float radius = 20;
 			int32_t lastValue = 0;
 		public:
-			CSpinner(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dot_size = 0.0f, olc::Pixel outline_color = olc::Pixel(236, 240, 241), olc::Pixel dot_color = olc::Pixel(46, 204, 113), olc::Pixel bg_color = olc::Pixel(0, 0, 0))
+			CSpinner(olc::vf2d position = olc::vf2d(0, 0), float radius = 0.0f, float dotSize = 0.0f, olc::Pixel outlineColor = olc::Pixel(236, 240, 241), olc::Pixel dotColor = olc::Pixel(46, 204, 113), olc::Pixel bgColor = olc::Pixel(0, 0, 0))
 			{
-				this->outline_color = outline_color;
-				this->dot_color = dot_color;
-				this->bg_color = bg_color;
+				this->outlineColor = outlineColor;
+				this->dotColor = dotColor;
+				this->backgroundColor = backgroundColor;
 				this->radius = radius;
 				this->x = position.x;
 				this->y = position.y;
-				this->dot_size = dot_size;
+				this->dotSize = dotSize;
 			}
 			float GetX() override
 			{
@@ -657,8 +654,8 @@ namespace olc
 			}
 			void UpdateControl() override
 			{
-				CBoundingBox* cbb = CreateBoundingBox(x - radius, y - radius, radius * 2, radius * 2);
-				if (IsInBounds(cbb->x, cbb->y, cbb->width, cbb->height, pge->GetMouseX(), pge->GetMouseY()))
+				CBoundingBox* boundingBox = CreateBoundingBox(x - radius, y - radius, radius * 2, radius * 2);
+				if (IsInBounds(boundingBox, pge->GetMouseX(), pge->GetMouseY()))
 				{
 					H_CHover(this);
 					if (lastValue != pge->GetMouseWheel())
@@ -680,9 +677,10 @@ namespace olc
 					angle = 0;
 				if (angle < 0)
 					angle = 0;
-				pge->FillCircle(x, y, radius, bg_color);
-				pge->DrawCircle(x, y, radius, outline_color);
-				pge->FillCircle(x + radius / 2 * sin(angle), y + radius / 2 * cos(angle), dot_size, dot_color);
+				pge->FillCircle(x, y, radius, backgroundColor);
+				pge->DrawCircle(x, y, radius, outlineColor);
+				pge->FillCircle(x + radius / 2 * sin(angle), y + radius / 2 * cos(angle), dotSize, dotColor);
+				delete boundingBox;
 			}
 		};
 
@@ -696,39 +694,39 @@ namespace olc
 		class CPool_Handler : public CEventHandler
 		{
 		public:
-			std::vector<CCheckBox*> cbx;
-			CPool_Handler(std::vector<CCheckBox*> cbx = {})
+			std::vector<CCheckBox*> checkboxVector;
+			CPool_Handler(std::vector<CCheckBox*> checkboxVector = {})
 			{
-				this->cbx = cbx;
+				this->checkboxVector = checkboxVector;
 			}
-			void AddItem(CCheckBox* cbx)
+			void AddItem(CCheckBox* checkbox)
 			{
-				this->cbx.push_back(cbx);
+				this->checkboxVector.push_back(checkbox);
 			}
-			void SetItems(std::vector<CCheckBox*> cbx)
+			void SetItems(std::vector<CCheckBox*> checkboxVector)
 			{
-				this->cbx = cbx;
+				this->checkboxVector = checkboxVector;
 			}
 			void CValueChanged(olc::PixelGameEngine* pge, BasicControl* ctrl, float nVal) override
 			{
-				for (CCheckBox* cb : cbx)
+				for (CCheckBox* cb : checkboxVector)
 				{
-					cb->bChecked = false;
+					cb->Checked = false;
 				}
-				((CCheckBox*)ctrl)->bChecked = true;
+				((CCheckBox*)ctrl)->Checked = true;
 			}
 		};
 
 		/* The easiest way of setting up a CPool_Handler */
-		CPool_Handler* SetupPool(std::vector<CCheckBox*> cbx)
+		CPool_Handler* SetupPool(std::vector<CCheckBox*> checkboxVector)
 		{
-			CPool_Handler* pool_h = new CPool_Handler();
-			pool_h->cbx = cbx;
-			for (CCheckBox* cb : cbx)
+			CPool_Handler* poolHandler = new CPool_Handler();
+			poolHandler->checkboxVector = checkboxVector;
+			for (CCheckBox* cb : checkboxVector)
 			{
-				cb->AddEventHandler(pool_h);
+				cb->AddEventHandler(poolHandler);
 			}
-			return pool_h;
+			return poolHandler;
 		}
 
 	}


### PR DESCRIPTION
_(I've accidentaly closed the old pull)_

This extension adds controls (and not only controls) to the olcPixelGameEngine and provides (basic) event handling for them.
List of currently available controls:
 - Button
 - Slider
 - CheckBox
 - Wheel _(Just like Slider but round and it rotates instead)_
 -  Progressbar _(Is not really a control. Thanks gurkanctn)_ 

In the newest update I've added a ***Frame***.
A Frame is basically a Container, that you can put some controls into.
.. And it's draggable, so using frames is not a complete nonsense.

There are some built-in event handlers as well, that provide more functionality
for already existing components.
The list of currently available built-in event handlers:
- CheckBoxPool _(Turns checboxes into a checkbox pool)_

Of course in the future there are going to be much more controls, event handlers, stuff or other bug fixing updates.