### PR TITLE
WinSock.h will no longer be included with windows.h

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -2526,7 +2526,9 @@ namespace olc
 // O------------------------------------------------------------------------------O
 #if defined(OLC_GFX_OPENGL10)
 #if defined(_WIN32)
+	#define _WINSOCKAPI_
 	#include <windows.h>
+	#undef _WINSOCKAPI_
 	#include <GL/gl.h>
 	typedef BOOL(WINAPI wglSwapInterval_t) (int interval);
 	static wglSwapInterval_t* wglSwapInterval = nullptr;


### PR DESCRIPTION
Just removing a pointless library from being included along with windows.h