### PR TITLE
Fixing an error on clang and silenting a warning on gcc.

### DIFF
--- a/Extensions/olcPGEX_RayCastWorld.h
+++ b/Extensions/olcPGEX_RayCastWorld.h
@@ -605,7 +605,7 @@ void olc::rcw::Engine::HandleObjectVsObject(std::shared_ptr<olc::rcw::Object> ob
 // Will be explained in upcoming video...
 bool olc::rcw::Engine::CastRayDDA(const olc::vf2d& vOrigin, const olc::vf2d& vDirection, sTileHit& hit)
 {
-	olc::vf2d vRayDelta = { sqrt(1 + (vDirection.y / vDirection.x) * (vDirection.y / vDirection.x)), sqrt(1 + (vDirection.x / vDirection.y) * (vDirection.x / vDirection.y)) };
+	olc::vf2d vRayDelta = { static_cast<float>(sqrt(1 + (vDirection.y / vDirection.x) * (vDirection.y / vDirection.x))), static_cast<float>(sqrt(1 + (vDirection.x / vDirection.y) * (vDirection.x / vDirection.y))) };
 
 	olc::vi2d vMapCheck = vOrigin;
 	olc::vf2d vSideDistance;


### PR DESCRIPTION
When compiling a project with the raycasting extension on Linux using clang 10.0.1 I get the following error message:
```
include/olcPGEX_RayCastWorld.h:608:26: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
        olc::vf2d vRayDelta = { sqrt(1 + (vDirection.y / vDirection.x) * (vDirection.y / vDirection.x)), sqrt(1 + (vDirection.x / vDirection.y) * (vDirection.x / vDirection.y)) };
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/olcPGEX_RayCastWorld.h:608:26: note: insert an explicit cast to silence this issue
        olc::vf2d vRayDelta = { sqrt(1 + (vDirection.y / vDirection.x) * (vDirection.y / vDirection.x)), sqrt(1 + (vDirection.x / vDirection.y) * (vDirection.x / vDirection.y)) };
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                static_cast<float>(                                                    )
include/olcPGEX_RayCastWorld.h:608:99: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
        olc::vf2d vRayDelta = { sqrt(1 + (vDirection.y / vDirection.x) * (vDirection.y / vDirection.x)), sqrt(1 + (vDirection.x / vDirection.y) * (vDirection.x / vDirection.y)) };
                                                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/olcPGEX_RayCastWorld.h:608:99: note: insert an explicit cast to silence this issue
        olc::vf2d vRayDelta = { sqrt(1 + (vDirection.y / vDirection.x) * (vDirection.y / vDirection.x)), sqrt(1 + (vDirection.x / vDirection.y) * (vDirection.x / vDirection.y)) };
                                                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                         static_cast<float>(                                                    )
```

It compile with g++, but it emit a warning. 
I have added the `static_cast<float>` as suggested in the message to prevent the error and silent the warning with gcc.