### PR TITLE
GLFW3 now as a standalone, OS-agnostic platform

### DIFF
--- a/olcExampleProgram.cpp
+++ b/olcExampleProgram.cpp
@@ -1,12 +1,16 @@
-#define OLC_PGE_APPLICATION
+#include <iostream>
+
 #define __GLFW__
+#define OLC_PGE_APPLICATION
 #include "olcPixelGameEngine.h"
 
+// Override base class with your custom functionality
 class Example : public olc::PixelGameEngine
 {
 public:
 	Example()
 	{
+		// Name you application
 		sAppName = "Example";
 	}
 
@@ -19,20 +23,29 @@ public:
 
 	bool OnUserUpdate(float fElapsedTime) override
 	{
-		// called once per frame
+		// called once per frame, draws random coloured pixels
 		for (int x = 0; x < ScreenWidth(); x++)
 			for (int y = 0; y < ScreenHeight(); y++)
-				Draw(x, y, olc::Pixel(rand() % 255, rand() % 255, rand()% 255));	
+				Draw(x, y, olc::Pixel(rand() % 256, rand() % 256, rand() % 256));
 		return true;
 	}
 };
 
-
 int main()
 {
-	Example demo;
-	if (demo.Construct(300, 100, 2, 2))
-		demo.Start();
 
+	float xScale = 1.0f, yScale = 1.0f;
+
+#if defined(__GLFW__)
+	glfwInit();
+	glfwGetMonitorContentScale(glfwGetPrimaryMonitor(), &xScale, &yScale);
+	glfwTerminate();
+#endif
+
+	Example demo;
+	if (demo.Construct(256, 240, xScale*3, yScale*3))
+		demo.Start();
 	return 0;
+
 }
+

--- a/olcExampleProgram.cpp
+++ b/olcExampleProgram.cpp
@@ -1,4 +1,5 @@
 #define OLC_PGE_APPLICATION
+#define __GLFW__
 #include "olcPixelGameEngine.h"
 
 class Example : public olc::PixelGameEngine
@@ -30,7 +31,7 @@ public:
 int main()
 {
 	Example demo;
-	if (demo.Construct(256, 240, 4, 4))
+	if (demo.Construct(300, 100, 2, 2))
 		demo.Start();
 
 	return 0;

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -2732,8 +2732,6 @@ namespace olc
 // | START RENDERER: OpenGL 1.0 (the original, the best...)                       |
 // O------------------------------------------------------------------------------O
 
-/* Handle platform windowing/input-related includes */
-// GLFW will take priority over platform specific includes
 #if defined(OLC_GFX_OPENGL10)
 
 #if defined(_WIN32)
@@ -2741,6 +2739,18 @@ namespace olc
 #pragma comment(lib,"opengl32.lib")
 #endif
 
+/* Handle platform-specific OpenGL includes */
+#if (defined(OLC_GFX_OPENGL10) && defined(_WIN32))  || defined(__linux__) || defined(__FreeBSD__)
+        #include <GL/gl.h>
+#elif defined(__APPLE__)
+        #include <OpenGL/OpenGL.h>
+        #include <OpenGL/gl.h>
+#else
+        #error "NO PLATFORM MATCHED (OpenGL includes)"
+#endif
+
+/* Handle platform windowing/input-related includes */
+// GLFW will take priority over platform specific includes
 #if defined(__GLFW__)
         #define GL_SILENCE_DEPRECATION
         #include <GLFW/glfw3.h>
@@ -2770,16 +2780,6 @@ namespace olc
         #include <OpenGL/glu.h>
 #else
 #error "NO PLATFORM MATCHED (windowing and input includes)"
-#endif
-
-/* Handle platform-specific OpenGL includes */
-#if (defined(OLC_GFX_OPENGL10) && defined(_WIN32))  || defined(__linux__) || defined(__FreeBSD__)
-        #include <GL/gl.h> 
-#elif defined(__APPLE__)
-        #include <OpenGL/OpenGL.h>
-        #include <OpenGL/gl.h>
-#else
-#error "NO PLATFORM MATCHED (OpenGL includes)"
 #endif
 
 namespace olc

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -4238,6 +4238,10 @@ namespace olc {
     }
 
     virtual olc::rcode ApplicationCleanUp() override {
+
+      glfwDestroyWindow(olc_Window);
+      glfwTerminate();
+      
       return olc::rcode::OK;
     }
 
@@ -4435,9 +4439,6 @@ namespace olc {
 
       ptrPGE->olc_Terminate();
       
-      glfwDestroyWindow(olc_Window);
-      glfwTerminate();
-
       return olc::OK;
     }
 

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -4102,7 +4102,7 @@ namespace olc {
       renderer->PrepareDevice();
 
       glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER,GLFW_FALSE);
-      glfwWindowHint(GLFW_RESIZABLE,GLFW_FALSE);
+      glfwWindowHint(GLFW_RESIZABLE,GLFW_TRUE);
       olc_Window = glfwCreateWindow(vWindowSize.x, vWindowSize.y, "OLC - PGE - GLFW", NULL, NULL);
       if (!olc_Window){
         glfwTerminate();
@@ -4122,17 +4122,18 @@ namespace olc {
       if (bFullScreen){
         vWindowSize.x = glfw_screen_width;
         vWindowSize.y = glfw_screen_height;
-        glfwSetWindowMonitor(olc_Window,glfwGetWindowMonitor(olc_Window),0,0,vWindowSize.x,vWindowSize.y,GLFW_DONT_CARE);
+        glfwSetWindowMonitor(olc_Window,glfwGetWindowMonitor(olc_Window),vWindowPos.x,vWindowPos.y,vWindowSize.x,vWindowSize.y,GLFW_DONT_CARE);
       }
       else{
-        glfwSetWindowMonitor(olc_Window,NULL,0,0,vWindowSize.x,vWindowSize.y,GLFW_DONT_CARE);
+//        glfwSetWindowMonitor(olc_Window,NULL,vWindowPos.x, vWindowPos.y,vWindowSize.x,vWindowSize.y,GLFW_DONT_CARE);
+		glfwSetWindowMonitor(olc_Window, NULL, vWindowPos.x, vWindowPos.y, vWindowSize.x, vWindowSize.y, GLFW_DONT_CARE);
       }
 
       if (vWindowSize.x > glfw_screen_width || vWindowSize.y > glfw_screen_height) {
         perror("ERROR: The specified window dimensions do not fit on your screen\n");
         return olc::FAIL;
       }
-      
+
       // Create Keyboard Mapping
       mapKeys[0x00] = Key::NONE;
       mapKeys['A'] = Key::A; mapKeys['B'] = Key::B; mapKeys['C'] = Key::C; mapKeys['D'] = Key::D; mapKeys['E'] = Key::E;

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -2842,7 +2842,7 @@ namespace olc
           X11::Window* olc_Window = nullptr;
           X11::XVisualInfo* olc_VisualInfo = nullptr;
 #else
-#error "NO PLATFORM MATCHED ()"
+          //#error "NO PLATFORM MATCHED ()"
 #endif
 
 

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -2770,8 +2770,6 @@ namespace olc
         #include <OpenGL/glu.h>
 #else
 #error "NO PLATFORM MATCHED (windowing and input includes)"
-//#include <OpenGL/OpenGL.h>
-//#include <OpenGL/gl.h>
 #endif
 
 /* Handle platform-specific OpenGL includes */
@@ -2783,49 +2781,6 @@ namespace olc
 #else
 #error "NO PLATFORM MATCHED (OpenGL includes)"
 #endif
-
-////////////////////osadifjaoisdfjoi
-///////
-///////#if defined(OLC_GFX_OPENGL10)
-///////	#if defined(_WIN32)
-///////	#include <windows.h>
-///////	#include <dwmapi.h>
-///////	#include <GL/gl.h>
-///////	#pragma comment(lib, "Dwmapi.lib")
-///////	typedef BOOL(WINAPI wglSwapInterval_t) (int interval);
-///////	static wglSwapInterval_t* wglSwapInterval = nullptr;
-///////	typedef HDC glDeviceContext_t;
-///////	typedef HGLRC glRenderContext_t;
-///////#endif
-///////
-///////#if defined(__linux__) || defined(__FreeBSD__)
-///////	#include <GL/gl.h>
-///////	namespace X11
-///////	{
-///////		#include <GL/glx.h>
-///////		#include <X11/X.h>
-///////		#include <X11/Xlib.h>
-///////	}
-///////
-///////	typedef int(glSwapInterval_t)(X11::Display* dpy, X11::GLXDrawable drawable, int interval);
-///////	static glSwapInterval_t* glSwapIntervalEXT;
-///////	typedef X11::GLXContext glDeviceContext_t;
-///////	typedef X11::GLXContext glRenderContext_t;
-///////#endif
-///////
-///////#if defined(__APPLE__) && !defined(__GLFW__)
-///////	#define GL_SILENCE_DEPRECATION
-///////	#include <GLUT/glut.h>
-///////	#include <OpenGL/OpenGL.h>
-///////	#include <OpenGL/gl.h>
-///////	#include <OpenGL/glu.h>
-///////#elif defined(__APPLE__) && defined(__GLFW__)
-///////        #define GL_SILENCE_DEPRECATION
-///////        #include <GLFW/glfw3.h>
-///////        #include <OpenGL/OpenGL.h>
-///////        #include <OpenGL/gl.h>
-/////////#include <OpenGL/glu.h>
-///////#endif
 
 namespace olc
 {
@@ -2849,33 +2804,8 @@ namespace olc
           X11::Window* olc_Window = nullptr;
           X11::XVisualInfo* olc_VisualInfo = nullptr;
 #else
-          //#error "NO PLATFORM MATCHED ()"
 #endif
 
-
-
-          /////////////iaosdjfoiasdjf
-          
-///#if defined(__APPLE__)
-///		bool mFullScreen = false;
-///#else
-///		glDeviceContext_t glDeviceContext = 0;
-///		glRenderContext_t glRenderContext = 0;
-///#endif
-///
-///		bool bSync = false;
-///
-///#if defined(__linux__) || defined(__FreeBSD__)
-///		X11::Display* olc_Display = nullptr;
-///		X11::Window* olc_Window = nullptr;
-///		X11::XVisualInfo* olc_VisualInfo = nullptr;
-///#endif
-///
-///#if defined(__APPLE__) && defined(__GLFW__)
-///                GLFWwindow* olc_Window = nullptr;
-///#endif
-          /////////////////////////////
-          
 	public:
 		void PrepareDevice() override
 		{ 
@@ -2978,88 +2908,6 @@ namespace olc
                   glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 #endif
                   return olc::rcode::OK;
-
-//////////////                  ////////////////aodifjoasidjfoi
-//////////////#if defined(_WIN32)
-//////////////			// Create Device Context
-//////////////			glDeviceContext = GetDC((HWND)(params[0]));
-//////////////			PIXELFORMATDESCRIPTOR pfd =
-//////////////			{
-//////////////				sizeof(PIXELFORMATDESCRIPTOR), 1,
-//////////////				PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
-//////////////				PFD_TYPE_RGBA, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-//////////////				PFD_MAIN_PLANE, 0, 0, 0, 0
-//////////////			};
-//////////////
-//////////////			int pf = 0;
-//////////////			if (!(pf = ChoosePixelFormat(glDeviceContext, &pfd))) return olc::FAIL;
-//////////////			SetPixelFormat(glDeviceContext, pf, &pfd);
-//////////////
-//////////////			if (!(glRenderContext = wglCreateContext(glDeviceContext))) return olc::FAIL;
-//////////////			wglMakeCurrent(glDeviceContext, glRenderContext);
-//////////////
-//////////////			// Remove Frame cap
-//////////////			wglSwapInterval = (wglSwapInterval_t*)wglGetProcAddress("wglSwapIntervalEXT");
-//////////////			if (wglSwapInterval && !bVSYNC) wglSwapInterval(0);
-//////////////			bSync = bVSYNC;
-//////////////#endif
-//////////////
-//////////////#if defined(__linux__) || defined(__FreeBSD__)
-//////////////			using namespace X11;
-//////////////			// Linux has tighter coupling between OpenGL and X11, so we store
-//////////////			// various "platform" handles in the renderer
-//////////////			olc_Display = (X11::Display*)(params[0]);
-//////////////			olc_Window = (X11::Window*)(params[1]);
-//////////////			olc_VisualInfo = (X11::XVisualInfo*)(params[2]);
-//////////////
-//////////////			glDeviceContext = glXCreateContext(olc_Display, olc_VisualInfo, nullptr, GL_TRUE);
-//////////////			glXMakeCurrent(olc_Display, *olc_Window, glDeviceContext);
-//////////////
-//////////////			XWindowAttributes gwa;
-//////////////			XGetWindowAttributes(olc_Display, *olc_Window, &gwa);
-//////////////			glViewport(0, 0, gwa.width, gwa.height);
-//////////////
-//////////////			glSwapIntervalEXT = nullptr;
-//////////////			glSwapIntervalEXT = (glSwapInterval_t*)glXGetProcAddress((unsigned char*)"glXSwapIntervalEXT");
-//////////////
-//////////////			if (glSwapIntervalEXT == nullptr && !bVSYNC)
-//////////////			{
-//////////////				printf("NOTE: Could not disable VSYNC, glXSwapIntervalEXT() was not found!\n");
-//////////////				printf("      Don't worry though, things will still work, it's just the\n");
-//////////////				printf("      frame rate will be capped to your monitors refresh rate - javidx9\n");
-//////////////			}
-//////////////
-//////////////			if (glSwapIntervalEXT != nullptr && !bVSYNC)
-//////////////				glSwapIntervalEXT(olc_Display, *olc_Window, 0);
-//////////////#endif		
-//////////////
-//////////////#if defined(__APPLE__) && !defined(__GLFW__)
-//////////////			mFullScreen = bFullScreen;
-//////////////			if (!bVSYNC)
-//////////////			{
-//////////////				GLint sync = 0;
-//////////////				CGLContextObj ctx = CGLGetCurrentContext();
-//////////////				if (ctx) CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
-//////////////			}
-//////////////#elif defined(__APPLE__) && defined(__GLFW__)
-//////////////                        
-//////////////                        olc_Window = (GLFWwindow *)(params[0]);
-//////////////                        glfwMakeContextCurrent(olc_Window);
-//////////////                        
-//////////////                        if (bVSYNC)
-//////////////                          glfwSwapInterval(1);
-//////////////                        else
-//////////////                          glfwSwapInterval(0);
-//////////////
-//////////////                        glEnable(GL_TEXTURE_2D); // Turn on texturing
-//////////////			glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
-//////////////                        
-//////////////#else
-//////////////			glEnable(GL_TEXTURE_2D); // Turn on texturing
-//////////////			glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
-//////////////#endif
-                  //return olc::rcode::OK;
-                        /////////////////////asdoijasdoifjaiojfio
 		}
 
 		olc::rcode DestroyDevice() override
@@ -3074,22 +2922,7 @@ namespace olc
 #elif defined(__APPLE__)
                   glutDestroyWindow(glutGetWindow());
 #endif
-                  
-///#if defined(_WIN32)
-///			wglDeleteContext(glRenderContext);
-///#endif
-///
-///#if defined(__linux__) || defined(__FreeBSD__)
-///			glXMakeCurrent(olc_Display, None, NULL);
-///			glXDestroyContext(olc_Display, glDeviceContext);
-///#endif
-///
-///#if defined(__APPLE__) && !defined(__GLFW__)
-///			glutDestroyWindow(glutGetWindow());
-///#elif defined(__APPLE__) && defined(__GLFW__)
-///                        // GLFW code here if needed
-///#endif
-			return olc::rcode::OK;
+                  return olc::rcode::OK;
 		}
 
 		void DisplayFrame() override
@@ -3104,25 +2937,9 @@ namespace olc
                   X11::glXSwapBuffers(olc_Display, *olc_Window);
 #elif defined(__APPLE__)
                   glutSwapBuffers();
-#endif
-                  
-//#if defined(_WIN32)
-//			SwapBuffers(glDeviceContext);
-//			if (bSync) DwmFlush(); // Woooohooooooo!!!! SMOOOOOOOTH!
-//#endif	
-//
-//#if defined(__linux__) || defined(__FreeBSD__)
-//			X11::glXSwapBuffers(olc_Display, *olc_Window);
-//#endif		
-//
-//#if defined(__APPLE__) && !defined(__GLFW__)
-//			glutSwapBuffers();
-//#elif defined(__APPLE__) && defined(__GLFW__)
-//                        glfwSwapBuffers(olc_Window);
-//                        
-//#endif
+#endif                  
 		}
-
+          
 		void PrepareDrawing() override
 		{
 			glEnable(GL_BLEND);
@@ -3331,8 +3148,6 @@ namespace olc
 // O------------------------------------------------------------------------------O
 // | END IMAGE LOADER: GDI+                                                       |
 // O------------------------------------------------------------------------------O
-
-
 
 
 // O------------------------------------------------------------------------------O
@@ -4230,7 +4045,6 @@ namespace olc {
 // O------------------------------------------------------------------------------O
 // | START PLATFORM: GLFW                                                         |
 // O------------------------------------------------------------------------------O
-//#if defined(__APPLE__) && defined(__GLFW__)
 #if defined(__GLFW__)
 namespace olc {
 
@@ -4295,8 +4109,6 @@ namespace olc {
         return olc::rcode::FAIL;
       }
 
-      glfwMakeContextCurrent(olc_Window);
-      
       int glfw_screen_width; 
       int glfw_screen_height;
       int glfw_x_leftcorner;
@@ -4357,10 +4169,8 @@ namespace olc {
       mapKeys[GLFW_KEY_RIGHT_CONTROL] = Key::CTRL;
 
       // Set event callbacks
-      //void mouse_button_callback(GLFWwindow* window, int button, int action, int mods){
-      //  if (button == GLFW_MOUSE_BUTTON_RIGHT && action == GLFW_PRESS)
-      //    popup_menu();
-      //}
+      // Callback signature:
+      //void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
       glfwSetMouseButtonCallback(olc_Window,
                                  [](GLFWwindow* w, int button, int action, int mods)->void{
       
@@ -4382,12 +4192,14 @@ namespace olc {
                                      ptrPGE->olc_UpdateMouseState(button_idx, false);
                                  });
       
+      // Callback signature:
       //static void cursor_position_callback(GLFWwindow* window, double xpos, double ypos)
       glfwSetCursorPosCallback(olc_Window,
                                [](GLFWwindow* window, double xpos, double ypos)->void{
                                  ptrPGE->olc_UpdateMouse((int)xpos, (int)ypos);
                                });
-      
+
+      // Callback signature:
       //void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
       glfwSetKeyCallback(olc_Window,
                          [](GLFWwindow* window, int key, int scancode, int action, int mods)->void{
@@ -4402,18 +4214,16 @@ namespace olc {
                            }
                            
                          });
-      
+
+      // Callback signature:
       //void cursor_enter_callback(GLFWwindow* window, int entered)
       glfwSetCursorEnterCallback(olc_Window, [](GLFWwindow * w, int entered)->void{
                                            if (entered)
                                              ptrPGE->olc_UpdateKeyFocus(true);
                                            else
                                              ptrPGE->olc_UpdateKeyFocus(false);
-
-                                           //std::cout << "Entered window: " << entered << std::endl;
                                          });
-
-
+      
       return olc::OK;
     }
 
@@ -4500,22 +4310,6 @@ namespace olc
                 platform = std::make_unique<olc::Platform_GLUT>();
 #endif
                 
-/////////#if defined(_WIN32)
-/////////		platform = std::make_unique<olc::Platform_Windows>();
-/////////#endif
-/////////
-/////////#if defined(__linux__) || defined(__FreeBSD__)
-/////////		platform = std::make_unique<olc::Platform_Linux>();
-/////////#endif
-/////////
-/////////#if defined(__APPLE__) && !defined(__GLFW__)
-/////////		platform = std::make_unique<olc::Platform_GLUT>();
-/////////#elif defined(__APPLE__) && defined(__GLFW__)
-/////////                platform = std::make_unique<olc::Platform_GLFW>();
-/////////#endif
-
-
-
 #if defined(OLC_GFX_OPENGL10)
 		renderer = std::make_unique<olc::Renderer_OGL10>();
 #endif

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -4246,6 +4246,13 @@ namespace olc {
   public:
     
     virtual olc::rcode ApplicationStartUp() override {
+
+      // Initialize GLFW and create our window
+      glfwSetErrorCallback(&glfwError);
+
+      if (!glfwInit())
+        return olc::rcode::FAIL;
+
       return olc::rcode::OK;
     }
 
@@ -4279,12 +4286,6 @@ namespace olc {
     virtual olc::rcode CreateWindowPane(const olc::vi2d& vWindowPos, olc::vi2d& vWindowSize, bool bFullScreen) override
     {
       renderer->PrepareDevice();
-
-      // Initialize GLFW and create our window
-      glfwSetErrorCallback(&glfwError);
-
-      if (!glfwInit())
-        return olc::rcode::FAIL;
 
       glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER,GLFW_FALSE);
       glfwWindowHint(GLFW_RESIZABLE,GLFW_FALSE);

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -331,6 +331,13 @@ int main()
 #endif
 #endif
 
+#if defined(__GLFW__)
+static void glfwError(int id, const char* description)
+{
+  std::cout << description << std::endl;
+}
+#endif
+
 // O------------------------------------------------------------------------------O
 // | olcPixelGameEngine INTERFACE DECLARATION                                     |
 // O------------------------------------------------------------------------------O
@@ -4274,6 +4281,8 @@ namespace olc {
       renderer->PrepareDevice();
 
       // Initialize GLFW and create our window
+      glfwSetErrorCallback(&glfwError);
+
       if (!glfwInit())
         return olc::rcode::FAIL;
 

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -260,6 +260,7 @@ int main()
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <mutex>
 
 // O------------------------------------------------------------------------------O
 // | COMPILER CONFIGURATION ODDITIES                                              |
@@ -2822,7 +2823,7 @@ namespace olc
 
           bool bSync = false;
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__GLFW__)
           glDeviceContext_t glDeviceContext = 0;
           glRenderContext_t glRenderContext = 0;
 #endif

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -2729,17 +2729,22 @@ namespace olc
 // GLFW will take priority over platform specific includes
 #if defined(OLC_GFX_OPENGL10)
 
+#if defined(_WIN32)
+#include <windows.h>
+#pragma comment(lib,"opengl32.lib")
+#endif
+
 #if defined(__GLFW__)
         #define GL_SILENCE_DEPRECATION
         #include <GLFW/glfw3.h>
-#elif defined(_WIN32)
-                #include <windows.h>
-                #include <dwmapi.h>
-                #pragma comment(lib, "Dwmapi.lib")
-                typedef BOOL(WINAPI wglSwapInterval_t) (int interval);
-                static wglSwapInterval_t* wglSwapInterval = nullptr;
-                typedef HDC glDeviceContext_t;
-                typedef HGLRC glRenderContext_t;
+#elif defined(_WIN32) 
+        #include <windows.h>
+        #include <dwmapi.h>
+        #pragma comment(lib, "Dwmapi.lib")
+        typedef BOOL(WINAPI wglSwapInterval_t) (int interval);
+        static wglSwapInterval_t* wglSwapInterval = nullptr;
+        typedef HDC glDeviceContext_t;
+        typedef HGLRC glRenderContext_t;
 #elif defined(__linux__) || defined(__FreeBSD__)
         namespace X11
         {

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -322,6 +322,14 @@ int main()
 #endif
 
 
+#if defined(__linux__) || defined(__APPLE__)
+#if defined(OLC_IMAGE_STB)
+#define PGE_ILOADER_STB
+#else
+#define	PGE_ILOADER_LIBPNG
+#endif
+#endif
+
 // O------------------------------------------------------------------------------O
 // | olcPixelGameEngine INTERFACE DECLARATION                                     |
 // O------------------------------------------------------------------------------O
@@ -448,9 +456,7 @@ namespace olc
 	typedef v2d_generic<float> vf2d;
 	typedef v2d_generic<double> vd2d;
 #endif
-
-
-
+  
 	// O------------------------------------------------------------------------------O
 	// | olc::HWButton - Represents the state of a hardware button (mouse/key/joy)    |
 	// O------------------------------------------------------------------------------O
@@ -911,9 +917,6 @@ namespace olc
 }
 
 #endif // OLC_PGE_DEF
-
-
-
 
 /*
 	Object Oriented Mode
@@ -1460,7 +1463,7 @@ namespace olc
 		return olc::OK;
 	}
 #endif
-
+  
 	void PixelGameEngine::SetDrawTarget(Sprite* target)
 	{
 		if (target)
@@ -2397,7 +2400,7 @@ namespace olc
 		}
 		SetPixelMode(m);
 	}
-
+  
 	void PixelGameEngine::SetPixelMode(Pixel::Mode m)
 	{ nPixelMode = m; }
 
@@ -2720,70 +2723,145 @@ namespace olc
 // O------------------------------------------------------------------------------O
 // | START RENDERER: OpenGL 1.0 (the original, the best...)                       |
 // O------------------------------------------------------------------------------O
+
+/* Handle platform windowing/input-related includes */
+// GLFW will take priority over platform specific includes
 #if defined(OLC_GFX_OPENGL10)
-	#if defined(_WIN32)
-	#include <windows.h>
-	#include <dwmapi.h>
-	#include <GL/gl.h>
-	#pragma comment(lib, "Dwmapi.lib")
-	typedef BOOL(WINAPI wglSwapInterval_t) (int interval);
-	static wglSwapInterval_t* wglSwapInterval = nullptr;
-	typedef HDC glDeviceContext_t;
-	typedef HGLRC glRenderContext_t;
-#endif
 
-#if defined(__linux__) || defined(__FreeBSD__)
-	#include <GL/gl.h>
-	namespace X11
-	{
-		#include <GL/glx.h>
-		#include <X11/X.h>
-		#include <X11/Xlib.h>
-	}
-
-	typedef int(glSwapInterval_t)(X11::Display* dpy, X11::GLXDrawable drawable, int interval);
-	static glSwapInterval_t* glSwapIntervalEXT;
-	typedef X11::GLXContext glDeviceContext_t;
-	typedef X11::GLXContext glRenderContext_t;
-#endif
-
-#if defined(__APPLE__) && !defined(__GLFW__)
-	#define GL_SILENCE_DEPRECATION
-	#include <GLUT/glut.h>
-	#include <OpenGL/OpenGL.h>
-	#include <OpenGL/gl.h>
-	#include <OpenGL/glu.h>
-#elif defined(__APPLE__) && defined(__GLFW__)
+#if defined(__GLFW__)
         #define GL_SILENCE_DEPRECATION
         #include <GLFW/glfw3.h>
+#elif defined(_WIN32)
+                #include <windows.h>
+                #include <dwmapi.h>
+                #pragma comment(lib, "Dwmapi.lib")
+                typedef BOOL(WINAPI wglSwapInterval_t) (int interval);
+                static wglSwapInterval_t* wglSwapInterval = nullptr;
+                typedef HDC glDeviceContext_t;
+                typedef HGLRC glRenderContext_t;
+#elif defined(__linux__) || defined(__FreeBSD__)
+        namespace X11
+        {
+                #include <GL/glx.h>
+                #include <X11/X.h>
+                #include <X11/Xlib.h>
+        }
+        
+        typedef int(glSwapInterval_t)(X11::Display* dpy, X11::GLXDrawable drawable, int interval);
+        static glSwapInterval_t* glSwapIntervalEXT;
+        typedef X11::GLXContext glDeviceContext_t;
+        typedef X11::GLXContext glRenderContext_t;
+#elif defined(__APPLE__)
+        #define GL_SILENCE_DEPRECATION
+        #include <GLUT/glut.h>
+        #include <OpenGL/glu.h>
+#else
+#error "NO PLATFORM MATCHED (windowing and input includes)"
+//#include <OpenGL/OpenGL.h>
+//#include <OpenGL/gl.h>
+#endif
+
+/* Handle platform-specific OpenGL includes */
+#if (defined(OLC_GFX_OPENGL10) && defined(_WIN32))  || defined(__linux__) || defined(__FreeBSD__)
+        #include <GL/gl.h> 
+#elif defined(__APPLE__)
         #include <OpenGL/OpenGL.h>
         #include <OpenGL/gl.h>
-//#include <OpenGL/glu.h>
+#else
+#error "NO PLATFORM MATCHED (OpenGL includes)"
 #endif
+
+////////////////////osadifjaoisdfjoi
+///////
+///////#if defined(OLC_GFX_OPENGL10)
+///////	#if defined(_WIN32)
+///////	#include <windows.h>
+///////	#include <dwmapi.h>
+///////	#include <GL/gl.h>
+///////	#pragma comment(lib, "Dwmapi.lib")
+///////	typedef BOOL(WINAPI wglSwapInterval_t) (int interval);
+///////	static wglSwapInterval_t* wglSwapInterval = nullptr;
+///////	typedef HDC glDeviceContext_t;
+///////	typedef HGLRC glRenderContext_t;
+///////#endif
+///////
+///////#if defined(__linux__) || defined(__FreeBSD__)
+///////	#include <GL/gl.h>
+///////	namespace X11
+///////	{
+///////		#include <GL/glx.h>
+///////		#include <X11/X.h>
+///////		#include <X11/Xlib.h>
+///////	}
+///////
+///////	typedef int(glSwapInterval_t)(X11::Display* dpy, X11::GLXDrawable drawable, int interval);
+///////	static glSwapInterval_t* glSwapIntervalEXT;
+///////	typedef X11::GLXContext glDeviceContext_t;
+///////	typedef X11::GLXContext glRenderContext_t;
+///////#endif
+///////
+///////#if defined(__APPLE__) && !defined(__GLFW__)
+///////	#define GL_SILENCE_DEPRECATION
+///////	#include <GLUT/glut.h>
+///////	#include <OpenGL/OpenGL.h>
+///////	#include <OpenGL/gl.h>
+///////	#include <OpenGL/glu.h>
+///////#elif defined(__APPLE__) && defined(__GLFW__)
+///////        #define GL_SILENCE_DEPRECATION
+///////        #include <GLFW/glfw3.h>
+///////        #include <OpenGL/OpenGL.h>
+///////        #include <OpenGL/gl.h>
+/////////#include <OpenGL/glu.h>
+///////#endif
 
 namespace olc
 {
 	class Renderer_OGL10 : public olc::Renderer
 	{
 	private:
-#if defined(__APPLE__)
-		bool mFullScreen = false;
+
+          bool bSync = false;
+
+#if !defined(__APPLE__)
+          glDeviceContext_t glDeviceContext = 0;
+          glRenderContext_t glRenderContext = 0;
+#endif
+          
+#if defined(__GLFW__)
+          GLFWwindow* olc_Window = nullptr;
+#elif defined(__APPLE__)
+          bool mFullScreen = false;
+#elif defined(__linux__) || defined(__FreeBSD__)
+          X11::Display* olc_Display = nullptr;
+          X11::Window* olc_Window = nullptr;
+          X11::XVisualInfo* olc_VisualInfo = nullptr;
 #else
-		glDeviceContext_t glDeviceContext = 0;
-		glRenderContext_t glRenderContext = 0;
+#error "NO PLATFORM MATCHED ()"
 #endif
 
-		bool bSync = false;
 
-#if defined(__linux__) || defined(__FreeBSD__)
-		X11::Display* olc_Display = nullptr;
-		X11::Window* olc_Window = nullptr;
-		X11::XVisualInfo* olc_VisualInfo = nullptr;
-#endif
 
-#if defined(__APPLE__) && defined(__GLFW__)
-                GLFWwindow* olc_Window = nullptr;
-#endif
+          /////////////iaosdjfoiasdjf
+          
+///#if defined(__APPLE__)
+///		bool mFullScreen = false;
+///#else
+///		glDeviceContext_t glDeviceContext = 0;
+///		glRenderContext_t glRenderContext = 0;
+///#endif
+///
+///		bool bSync = false;
+///
+///#if defined(__linux__) || defined(__FreeBSD__)
+///		X11::Display* olc_Display = nullptr;
+///		X11::Window* olc_Window = nullptr;
+///		X11::XVisualInfo* olc_VisualInfo = nullptr;
+///#endif
+///
+///#if defined(__APPLE__) && defined(__GLFW__)
+///                GLFWwindow* olc_Window = nullptr;
+///#endif
+          /////////////////////////////
           
 	public:
 		void PrepareDevice() override
@@ -2804,131 +2882,232 @@ namespace olc
 
 			glEnable(GL_TEXTURE_2D); // Turn on texturing
 			glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
-#elif defined(__APPLE__) && defined(__GLFW__)
-			// GLFW CODE HERE!!
 #endif
 		}
 
 		olc::rcode CreateDevice(std::vector<void*> params, bool bFullScreen, bool bVSYNC) override
 		{
-#if defined(_WIN32)
-			// Create Device Context
-			glDeviceContext = GetDC((HWND)(params[0]));
-			PIXELFORMATDESCRIPTOR pfd =
-			{
-				sizeof(PIXELFORMATDESCRIPTOR), 1,
-				PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
-				PFD_TYPE_RGBA, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				PFD_MAIN_PLANE, 0, 0, 0, 0
-			};
 
-			int pf = 0;
-			if (!(pf = ChoosePixelFormat(glDeviceContext, &pfd))) return olc::FAIL;
-			SetPixelFormat(glDeviceContext, pf, &pfd);
 
-			if (!(glRenderContext = wglCreateContext(glDeviceContext))) return olc::FAIL;
-			wglMakeCurrent(glDeviceContext, glRenderContext);
+#if defined(__GLFW__)
+                  olc_Window = (GLFWwindow *)(params[0]);
+                  glfwMakeContextCurrent(olc_Window);
+                        
+                  if (bVSYNC)
+                    glfwSwapInterval(1);
+                  else
+                    glfwSwapInterval(0);
 
-			// Remove Frame cap
-			wglSwapInterval = (wglSwapInterval_t*)wglGetProcAddress("wglSwapIntervalEXT");
-			if (wglSwapInterval && !bVSYNC) wglSwapInterval(0);
-			bSync = bVSYNC;
+                  glEnable(GL_TEXTURE_2D); // Turn on texturing
+                  glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);                        
+#elif defined(_WIN32)
+                  // Create Device Context
+                  glDeviceContext = GetDC((HWND)(params[0]));
+                  PIXELFORMATDESCRIPTOR pfd =
+                    {
+                     sizeof(PIXELFORMATDESCRIPTOR), 1,
+                     PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+                     PFD_TYPE_RGBA, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                     PFD_MAIN_PLANE, 0, 0, 0, 0
+                    };
+
+                  int pf = 0;
+                  if (!(pf = ChoosePixelFormat(glDeviceContext, &pfd))) return olc::FAIL;
+                  SetPixelFormat(glDeviceContext, pf, &pfd);
+
+                  if (!(glRenderContext = wglCreateContext(glDeviceContext))) return olc::FAIL;
+                  wglMakeCurrent(glDeviceContext, glRenderContext);
+
+                  // Remove Frame cap
+                  wglSwapInterval = (wglSwapInterval_t*)wglGetProcAddress("wglSwapIntervalEXT");
+                  if (wglSwapInterval && !bVSYNC) wglSwapInterval(0);
+                  bSync = bVSYNC;
+#elif defined(__linux__) || defined(__FreeBSD__)
+                  using namespace X11;
+                  // Linux has tighter coupling between OpenGL and X11, so we store
+                  // various "platform" handles in the renderer
+                  olc_Display = (X11::Display*)(params[0]);
+                  olc_Window = (X11::Window*)(params[1]);
+                  olc_VisualInfo = (X11::XVisualInfo*)(params[2]);
+
+                  glDeviceContext = glXCreateContext(olc_Display, olc_VisualInfo, nullptr, GL_TRUE);
+                  glXMakeCurrent(olc_Display, *olc_Window, glDeviceContext);
+
+                  XWindowAttributes gwa;
+                  XGetWindowAttributes(olc_Display, *olc_Window, &gwa);
+                  glViewport(0, 0, gwa.width, gwa.height);
+
+                  glSwapIntervalEXT = nullptr;
+                  glSwapIntervalEXT = (glSwapInterval_t*)glXGetProcAddress((unsigned char*)"glXSwapIntervalEXT");
+
+                  if (glSwapIntervalEXT == nullptr && !bVSYNC)
+                    {
+                      printf("NOTE: Could not disable VSYNC, glXSwapIntervalEXT() was not found!\n");
+                      printf("      Don't worry though, things will still work, it's just the\n");
+                      printf("      frame rate will be capped to your monitors refresh rate - javidx9\n");
+                    }
+
+                  if (glSwapIntervalEXT != nullptr && !bVSYNC)
+                    glSwapIntervalEXT(olc_Display, *olc_Window, 0);
+#elif defined(__APPLE__)
+                  mFullScreen = bFullScreen;
+                  if (!bVSYNC)
+                    {
+                      GLint sync = 0;
+                      CGLContextObj ctx = CGLGetCurrentContext();
+                      if (ctx) CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
+                    }
 #endif
 
-#if defined(__linux__) || defined(__FreeBSD__)
-			using namespace X11;
-			// Linux has tighter coupling between OpenGL and X11, so we store
-			// various "platform" handles in the renderer
-			olc_Display = (X11::Display*)(params[0]);
-			olc_Window = (X11::Window*)(params[1]);
-			olc_VisualInfo = (X11::XVisualInfo*)(params[2]);
-
-			glDeviceContext = glXCreateContext(olc_Display, olc_VisualInfo, nullptr, GL_TRUE);
-			glXMakeCurrent(olc_Display, *olc_Window, glDeviceContext);
-
-			XWindowAttributes gwa;
-			XGetWindowAttributes(olc_Display, *olc_Window, &gwa);
-			glViewport(0, 0, gwa.width, gwa.height);
-
-			glSwapIntervalEXT = nullptr;
-			glSwapIntervalEXT = (glSwapInterval_t*)glXGetProcAddress((unsigned char*)"glXSwapIntervalEXT");
-
-			if (glSwapIntervalEXT == nullptr && !bVSYNC)
-			{
-				printf("NOTE: Could not disable VSYNC, glXSwapIntervalEXT() was not found!\n");
-				printf("      Don't worry though, things will still work, it's just the\n");
-				printf("      frame rate will be capped to your monitors refresh rate - javidx9\n");
-			}
-
-			if (glSwapIntervalEXT != nullptr && !bVSYNC)
-				glSwapIntervalEXT(olc_Display, *olc_Window, 0);
-#endif		
-
-#if defined(__APPLE__) && !defined(__GLFW__)
-			mFullScreen = bFullScreen;
-			if (!bVSYNC)
-			{
-				GLint sync = 0;
-				CGLContextObj ctx = CGLGetCurrentContext();
-				if (ctx) CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
-			}
-#elif defined(__APPLE__) && defined(__GLFW__)
-                        
-                        // GLFW CODE HERE!!!
-                        olc_Window = (GLFWwindow *)(params[0]);
-                        glfwMakeContextCurrent(olc_Window);
-                        
-                        if (bVSYNC)
-                          glfwSwapInterval(1);
-                        else
-                          glfwSwapInterval(0);
-
-                        glEnable(GL_TEXTURE_2D); // Turn on texturing
-			glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
-                        
-#else
-			glEnable(GL_TEXTURE_2D); // Turn on texturing
-			glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
+                  // @JOHN: Double check that this needs to be blocked 
+#if !defined(__APPLE__)
+                  glEnable(GL_TEXTURE_2D); // Turn on texturing
+                  glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
 #endif
-			return olc::rcode::OK;
+                  return olc::rcode::OK;
+
+//////////////                  ////////////////aodifjoasidjfoi
+//////////////#if defined(_WIN32)
+//////////////			// Create Device Context
+//////////////			glDeviceContext = GetDC((HWND)(params[0]));
+//////////////			PIXELFORMATDESCRIPTOR pfd =
+//////////////			{
+//////////////				sizeof(PIXELFORMATDESCRIPTOR), 1,
+//////////////				PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+//////////////				PFD_TYPE_RGBA, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+//////////////				PFD_MAIN_PLANE, 0, 0, 0, 0
+//////////////			};
+//////////////
+//////////////			int pf = 0;
+//////////////			if (!(pf = ChoosePixelFormat(glDeviceContext, &pfd))) return olc::FAIL;
+//////////////			SetPixelFormat(glDeviceContext, pf, &pfd);
+//////////////
+//////////////			if (!(glRenderContext = wglCreateContext(glDeviceContext))) return olc::FAIL;
+//////////////			wglMakeCurrent(glDeviceContext, glRenderContext);
+//////////////
+//////////////			// Remove Frame cap
+//////////////			wglSwapInterval = (wglSwapInterval_t*)wglGetProcAddress("wglSwapIntervalEXT");
+//////////////			if (wglSwapInterval && !bVSYNC) wglSwapInterval(0);
+//////////////			bSync = bVSYNC;
+//////////////#endif
+//////////////
+//////////////#if defined(__linux__) || defined(__FreeBSD__)
+//////////////			using namespace X11;
+//////////////			// Linux has tighter coupling between OpenGL and X11, so we store
+//////////////			// various "platform" handles in the renderer
+//////////////			olc_Display = (X11::Display*)(params[0]);
+//////////////			olc_Window = (X11::Window*)(params[1]);
+//////////////			olc_VisualInfo = (X11::XVisualInfo*)(params[2]);
+//////////////
+//////////////			glDeviceContext = glXCreateContext(olc_Display, olc_VisualInfo, nullptr, GL_TRUE);
+//////////////			glXMakeCurrent(olc_Display, *olc_Window, glDeviceContext);
+//////////////
+//////////////			XWindowAttributes gwa;
+//////////////			XGetWindowAttributes(olc_Display, *olc_Window, &gwa);
+//////////////			glViewport(0, 0, gwa.width, gwa.height);
+//////////////
+//////////////			glSwapIntervalEXT = nullptr;
+//////////////			glSwapIntervalEXT = (glSwapInterval_t*)glXGetProcAddress((unsigned char*)"glXSwapIntervalEXT");
+//////////////
+//////////////			if (glSwapIntervalEXT == nullptr && !bVSYNC)
+//////////////			{
+//////////////				printf("NOTE: Could not disable VSYNC, glXSwapIntervalEXT() was not found!\n");
+//////////////				printf("      Don't worry though, things will still work, it's just the\n");
+//////////////				printf("      frame rate will be capped to your monitors refresh rate - javidx9\n");
+//////////////			}
+//////////////
+//////////////			if (glSwapIntervalEXT != nullptr && !bVSYNC)
+//////////////				glSwapIntervalEXT(olc_Display, *olc_Window, 0);
+//////////////#endif		
+//////////////
+//////////////#if defined(__APPLE__) && !defined(__GLFW__)
+//////////////			mFullScreen = bFullScreen;
+//////////////			if (!bVSYNC)
+//////////////			{
+//////////////				GLint sync = 0;
+//////////////				CGLContextObj ctx = CGLGetCurrentContext();
+//////////////				if (ctx) CGLSetParameter(ctx, kCGLCPSwapInterval, &sync);
+//////////////			}
+//////////////#elif defined(__APPLE__) && defined(__GLFW__)
+//////////////                        
+//////////////                        olc_Window = (GLFWwindow *)(params[0]);
+//////////////                        glfwMakeContextCurrent(olc_Window);
+//////////////                        
+//////////////                        if (bVSYNC)
+//////////////                          glfwSwapInterval(1);
+//////////////                        else
+//////////////                          glfwSwapInterval(0);
+//////////////
+//////////////                        glEnable(GL_TEXTURE_2D); // Turn on texturing
+//////////////			glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
+//////////////                        
+//////////////#else
+//////////////			glEnable(GL_TEXTURE_2D); // Turn on texturing
+//////////////			glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
+//////////////#endif
+                  //return olc::rcode::OK;
+                        /////////////////////asdoijasdoifjaiojfio
 		}
 
 		olc::rcode DestroyDevice() override
 		{
-#if defined(_WIN32)
-			wglDeleteContext(glRenderContext);
+#if defined(__GLFW__)
+                  // GLFW Code here
+#elif defined(_WIN32)
+                  wglDeleteContext(glRenderContext);
+#elif defined(__linux__) || defined(__FreeBSD__)
+                  glXMakeCurrent(olc_Display, None, NULL);
+                  glXDestroyContext(olc_Display, glDeviceContext);
+#elif defined(__APPLE__)
+                  glutDestroyWindow(glutGetWindow());
 #endif
-
-#if defined(__linux__) || defined(__FreeBSD__)
-			glXMakeCurrent(olc_Display, None, NULL);
-			glXDestroyContext(olc_Display, glDeviceContext);
-#endif
-
-#if defined(__APPLE__) && !defined(__GLFW__)
-			glutDestroyWindow(glutGetWindow());
-#elif defined(__APPLE__) && defined(__GLFW__)
-                        // GLFW code here if needed
-#endif
+                  
+///#if defined(_WIN32)
+///			wglDeleteContext(glRenderContext);
+///#endif
+///
+///#if defined(__linux__) || defined(__FreeBSD__)
+///			glXMakeCurrent(olc_Display, None, NULL);
+///			glXDestroyContext(olc_Display, glDeviceContext);
+///#endif
+///
+///#if defined(__APPLE__) && !defined(__GLFW__)
+///			glutDestroyWindow(glutGetWindow());
+///#elif defined(__APPLE__) && defined(__GLFW__)
+///                        // GLFW code here if needed
+///#endif
 			return olc::rcode::OK;
 		}
 
 		void DisplayFrame() override
 		{
-#if defined(_WIN32)
-			SwapBuffers(glDeviceContext);
-			if (bSync) DwmFlush(); // Woooohooooooo!!!! SMOOOOOOOTH!
-#endif	
 
-#if defined(__linux__) || defined(__FreeBSD__)
-			X11::glXSwapBuffers(olc_Display, *olc_Window);
-#endif		
-
-#if defined(__APPLE__) && !defined(__GLFW__)
-			glutSwapBuffers();
-#elif defined(__APPLE__) && defined(__GLFW__)
-                        glfwSwapBuffers(olc_Window);
-                        
+#if defined(__GLFW__)
+                  glfwSwapBuffers(olc_Window);
+#elif defined(_WIN32)
+                  SwapBuffers(glDeviceContext);
+                  if (bSync) DwmFlush(); // Woooohooooooo!!!! SMOOOOOOOTH!
+#elif defined(__linux__) || defined(__FreeBSD__)
+                  X11::glXSwapBuffers(olc_Display, *olc_Window);
+#elif defined(__APPLE__)
+                  glutSwapBuffers();
 #endif
+                  
+//#if defined(_WIN32)
+//			SwapBuffers(glDeviceContext);
+//			if (bSync) DwmFlush(); // Woooohooooooo!!!! SMOOOOOOOTH!
+//#endif	
+//
+//#if defined(__linux__) || defined(__FreeBSD__)
+//			X11::glXSwapBuffers(olc_Display, *olc_Window);
+//#endif		
+//
+//#if defined(__APPLE__) && !defined(__GLFW__)
+//			glutSwapBuffers();
+//#elif defined(__APPLE__) && defined(__GLFW__)
+//                        glfwSwapBuffers(olc_Window);
+//                        
+//#endif
 		}
 
 		void PrepareDrawing() override
@@ -3023,9 +3202,7 @@ namespace olc
 		void UpdateViewport(const olc::vi2d& pos, const olc::vi2d& size) override
 		{
 #if defined(__APPLE__) && !defined(__GLFW__)
-			if (!mFullScreen) glutReshapeWindow(size.x, size.y);
-                        //#elif defined(__APPLE__) && defined(__GLFW__)
-                        // GLFW code here
+			if (!mFullScreen) glutReshapeWindow(size.x, size.y);                 
 #else
 			glViewport(pos.x, pos.y, size.x, size.y);
 #endif
@@ -3342,7 +3519,7 @@ namespace olc
 // O------------------------------------------------------------------------------O
 // | START PLATFORM: MICROSOFT WINDOWS XP, VISTA, 7, 8, 10                        |
 // O------------------------------------------------------------------------------O
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__GLFW__)
 #if !defined(__MINGW32__)
 #pragma comment(lib, "user32.lib")		// Visual Studio Only
 #pragma comment(lib, "gdi32.lib")		// For other Windows Compilers please add
@@ -3556,7 +3733,7 @@ namespace olc
 // O------------------------------------------------------------------------------O
 // | START PLATFORM: LINUX                                                        |
 // O------------------------------------------------------------------------------O
-#if defined(__linux__) || defined(__FreeBSD__)
+#if (defined(__linux__) || defined(__FreeBSD__)) && !defined(__GLFW__) 
 namespace olc
 {
 	class Platform_Linux : public olc::Platform
@@ -4040,7 +4217,8 @@ namespace olc {
 // O------------------------------------------------------------------------------O
 // | START PLATFORM: GLFW                                                         |
 // O------------------------------------------------------------------------------O
-#if defined(__APPLE__) && defined(__GLFW__)
+//#if defined(__APPLE__) && defined(__GLFW__)
+#if defined(__GLFW__)
 namespace olc {
 
   class Platform_GLFW : public olc::Platform
@@ -4293,23 +4471,31 @@ namespace olc
 #if defined(PGE_ILOADER_STB)
 		olc::Sprite::loader = std::make_unique<olc::ImageLoader_STB>();
 #endif
+                
 
-
-
-
-#if defined(_WIN32)
-		platform = std::make_unique<olc::Platform_Windows>();
-#endif
-
-#if defined(__linux__) || defined(__FreeBSD__)
-		platform = std::make_unique<olc::Platform_Linux>();
-#endif
-
-#if defined(__APPLE__) && !defined(__GLFW__)
-		platform = std::make_unique<olc::Platform_GLUT>();
-#elif defined(__APPLE__) && defined(__GLFW__)
+#if defined(__GLFW__)
                 platform = std::make_unique<olc::Platform_GLFW>();
+#elif defined(_WIN32)
+                platform = std::make_unique<olc::Platform_Windows>();
+#elif defined(__linux__) || defined(__FreeBSD__)
+                platform = std::make_unique<olc::Platform_Linux>();
+#elif defined(__APPLE__)
+                platform = std::make_unique<olc::Platform_GLUT>();
 #endif
+                
+/////////#if defined(_WIN32)
+/////////		platform = std::make_unique<olc::Platform_Windows>();
+/////////#endif
+/////////
+/////////#if defined(__linux__) || defined(__FreeBSD__)
+/////////		platform = std::make_unique<olc::Platform_Linux>();
+/////////#endif
+/////////
+/////////#if defined(__APPLE__) && !defined(__GLFW__)
+/////////		platform = std::make_unique<olc::Platform_GLUT>();
+/////////#elif defined(__APPLE__) && defined(__GLFW__)
+/////////                platform = std::make_unique<olc::Platform_GLFW>();
+/////////#endif
 
 
 


### PR DESCRIPTION
# What is this?

This is a followup to my other pull request "New platform: GLFW3!" (https://github.com/OneLoneCoder/olcPixelGameEngine/pull/172).  There seemed to be enough interest in actually leveraging GLFW's cross-platform nature for me to go ahead and make the changes necessary to get a fully cross platform version going.  I was on vacation so I figured "why not..."

I will try to keep the notes here short since the "why" and "how" is already pretty well laid out in the other PR.

This PR just extends that work to Windows and Linux (and of course, Mac).  

As of today, it is tested and working on: 

- Windows 10
- Linux (Ubuntu 20.04 LTS)
- Mac OS 10.15.5

Thank you to @olc-slav, @MumflrFumperdink, and @Zij-IT for the help in testing and feedback while building.  

Please feel free to reach out with any further suggestions or feedback!

## Known "issue:"
I did my best to preserve exact behavior between the GLFW platform and the pre-existing platforms.  With high-DPI screens such as Mac's Retina displays, or some Windows displays depending on configuration, there is a "scaling factor" applied to the screen.  GLFW will **only** render into the native pixel sizes and will ignore this platform-level scaling factor.  Windows in particular is very good about respecting this scaling factor.

While this is not truly a bug, just a difference in behavior, it does create a disparity between the native platforms and GLFW.  

Fortunately GLFW gives us a tool to read the scaling factor from the monitor, which we can then pass to our "Contruct" method which will compensate for us, if we so desire:

```c++
int main()
{

	float xScale = 1.0f, yScale = 1.0f;

#if defined(__GLFW__)
	glfwInit();
	glfwGetMonitorContentScale(glfwGetPrimaryMonitor(), &xScale, &yScale);
	glfwTerminate();
#endif

	Example demo;
	if (demo.Construct(256, 240, xScale*3, yScale*3))
		demo.Start();
	return 0;

}
```

The above code is already present in olcExampleProgram.cpp of the PR.

# Compiling instructions

All of the pre-existing compilations should work exactly as they did before (i.e. the core behavior of the PGE remains exactly the same).  

## Enabling GLFW (Mac, Linux, Windows)
To use the GLFW-flavored platform instead of the preexisting system platforms, add `#define __GLFW__` **before** your `#include "olcPixelGameEngine"`:

```c++
#define __GLFW__
#define OLC_PGE_APPLICATION
#include "olcPixelGameEngine.h"
```

## Compiling
### Mac:

```bash
clang++ -std=c++17 olcExampleProgram.cpp -o olcExampleProgram -lz -lpng -framework OpenGL -framework OpenGL -lglfw3 -framework Cocoa -framework IOKit -framework CoreFoundation 
```

### Linux:

```bash
g++ -std=c++17 olcExampleProgram.cpp -o olcExampleProgram -lz -lpng -lglfw -lOpenGL -lpthread
```

### Windows (with Visual Studio)

#### TL;DR:
Download the latest GLFW precompiled libraries and configure your project to use the `\path\to\glfw-***\include` for headers and link against the `glfw3.lib` library.  Ensure you download and link against your desired architecture (32-bit or 64-bit).

#### (More) Detailed Instructions:

1. Download the latest release from https://www.glfw.org/ and unzip into a directory on your machine (for example C:\Users\username\Code)

2. Create a new, blank Visual Studio C++ project and copy the contents of olcExampleProgram.cpp into a new “main.cpp” file. 

   *(Note the contents of olcExampleProgram are different in the glfw_standalone_platform branch)*

3. Add the olcPixelGameEngine.h header into the project
4. In your project settings (Project -> {solution name} Properties):
   1. Under “Configuration Properties” -> **“C/C++”** -> “All Options” add the glfw include directory to the “Additional Include Directories” property. E.g. C:\Users\username\Code\glfw-3.3.2\include
   2. Under “Configuration Properties” -> **“Linker”** -> “All Options”: 
       1. add the directory containing the glfw library to the “additional library directories” property, and 
       2. add “glfw3.lib” to the “Additional dependencies” property
