### PR TITLE
Fix warnings from -pedantic -Weff-c++

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -972,12 +972,12 @@ namespace olc
 		// State of keyboard		
 		bool		pKeyNewState[256] = { 0 };
 		bool		pKeyOldState[256] = { 0 };
-		HWButton	pKeyboardState[256] = { 0 };
+		HWButton	pKeyboardState[256] = { { 0 } };
 
 		// State of mouse
 		bool		pMouseNewState[nMouseButtons] = { 0 };
 		bool		pMouseOldState[nMouseButtons] = { 0 };
-		HWButton	pMouseState[nMouseButtons] = { 0 };
+		HWButton	pMouseState[nMouseButtons] = { { 0 } };
 
 		// The main engine thread
 		void		EngineThread();

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -416,7 +416,10 @@ namespace olc
 		union
 		{
 			uint32_t n = nDefaultPixel;
+			#pragma GCC diagnostic push
+			#pragma GCC diagnostic ignored "-Wpedantic"
 			struct { uint8_t r; uint8_t g; uint8_t b; uint8_t a; };
+			#pragma GCC diagnostic pop
 		};
 
 		enum Mode { NORMAL, MASK, ALPHA, CUSTOM };

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -699,6 +699,9 @@ namespace olc
 
 	struct LayerDesc
 	{
+		LayerDesc() : vecDecalInstance{} {}
+		LayerDesc(const LayerDesc&) = default;
+		LayerDesc& operator=(const LayerDesc&) = delete;
 		olc::vf2d vOffset = { 0, 0 };
 		olc::vf2d vScale = { 1, 1 };
 		bool bShow = false;
@@ -1395,14 +1398,14 @@ namespace olc
 	//=============================================================
 	// Resource Packs - Allows you to store files in one large 
 	// scrambled file - Thanks MaGetzUb for debugging a null char in std::stringstream bug
-	ResourceBuffer::ResourceBuffer(std::ifstream& ifs, uint32_t offset, uint32_t size)
+	ResourceBuffer::ResourceBuffer(std::ifstream& ifs, uint32_t offset, uint32_t size) : vMemory{}
 	{
 		vMemory.resize(size);
 		ifs.seekg(offset); ifs.read(vMemory.data(), vMemory.size());
 		setg(vMemory.data(), vMemory.data(), vMemory.data() + size);
 	}
 
-	ResourcePack::ResourcePack() { }
+	ResourcePack::ResourcePack() : mapFiles{}, baseFile{} { }
 	ResourcePack::~ResourcePack() { baseFile.close(); }
 
 	bool ResourcePack::AddFile(const std::string& sFile)
@@ -1571,9 +1574,9 @@ namespace olc
 	// O------------------------------------------------------------------------------O
 	// | olc::PixelGameEngine IMPLEMENTATION                                          |
 	// O------------------------------------------------------------------------------O
-	PixelGameEngine::PixelGameEngine()
+	PixelGameEngine::PixelGameEngine() : sAppName{"Undefined"}, vLayers{},
+	funcPixelMode{}, m_tp1{}, m_tp2{}, vFontSpacing{}
 	{
-		sAppName = "Undefined";
 		olc::PGEX::pge = this;
 
 		// Bring in relevant Platform & Rendering systems depending
@@ -3857,6 +3860,11 @@ namespace olc
 		X11::XSetWindowAttributes    olc_SetWindowAttribs;
 
 	public:
+		Platform_Linux() : olc_WindowRoot{}, olc_Window{}, olc_VisualInfo{},
+		olc_ColourMap{}, olc_SetWindowAttribs{} {}
+		Platform_Linux(const Platform_Linux&) = delete;
+		Platform_Linux& operator=(const Platform_Linux&) = delete;
+
 		virtual olc::rcode ApplicationStartUp() override
 		{ return olc::rcode::OK; }
 

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -1553,14 +1553,14 @@ namespace olc
 		size_t c = 0;
 		for (auto s : data)	o.push_back(s ^ key[(c++) % key.size()]);
 		return o;
-	};
+	}
 
 	std::string ResourcePack::makeposix(const std::string& path)
 	{
 		std::string o;
 		for (auto s : path) o += std::string(1, s == '\\' ? '/' : s);
 		return o;
-	};
+	}
 
 	// O------------------------------------------------------------------------------O
 	// | olc::PixelGameEngine IMPLEMENTATION                                          |
@@ -2984,7 +2984,7 @@ namespace olc
 	olc::PixelGameEngine* olc::Platform::ptrPGE = nullptr;
 	olc::PixelGameEngine* olc::Renderer::ptrPGE = nullptr;
 	std::unique_ptr<ImageLoader> olc::Sprite::loader = nullptr;
-};
+}
 
 
 

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -598,6 +598,7 @@ namespace olc
 		Sprite(const std::string& sImageFile, olc::ResourcePack* pack = nullptr);
 		Sprite(int32_t w, int32_t h);
 		Sprite(const olc::Sprite&) = delete;
+		olc::Sprite& operator=(const olc::Sprite&) = delete;
 		~Sprite();
 
 	public:
@@ -628,6 +629,7 @@ namespace olc
 		static std::unique_ptr<olc::ImageLoader> loader;
 	};
 
+
 	// O------------------------------------------------------------------------------O
 	// | olc::Decal - A GPU resident storage of an olc::Sprite                        |
 	// O------------------------------------------------------------------------------O
@@ -635,6 +637,8 @@ namespace olc
 	{
 	public:
 		Decal(olc::Sprite* spr, bool filter = false);
+		Decal(const Decal&) = delete;
+		Decal& operator=(const Decal&) = delete;
 		virtual ~Decal();
 		void Update();
 
@@ -756,6 +760,8 @@ namespace olc
 	{
 	public:
 		PixelGameEngine();
+		PixelGameEngine(const PixelGameEngine&) = delete;
+		PixelGameEngine& operator=(const PixelGameEngine&) = delete;
 		virtual ~PixelGameEngine();
 	public:
 		olc::rcode Construct(int32_t screen_w, int32_t screen_h, int32_t pixel_w, int32_t pixel_h,

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -3084,7 +3084,7 @@ namespace olc
 #endif
 		}
 
-		olc::rcode CreateDevice(std::vector<void*> params, bool bFullScreen, bool bVSYNC) override
+		olc::rcode CreateDevice(std::vector<void*> params, bool, bool bVSYNC) override
 		{
 #if defined(OLC_PLATFORM_WINAPI)
 			// Create Device Context
@@ -3553,7 +3553,7 @@ namespace olc
 			return olc::rcode::FAIL;
 		}
 
-		olc::rcode SaveImageResource(olc::Sprite* spr, const std::string& sImageFile) override
+		olc::rcode SaveImageResource(olc::Sprite*, const std::string&) override
 		{
 			return olc::rcode::OK;
 		}

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -3198,7 +3198,7 @@ namespace olc
 			SetDecalMode(olc::DecalMode::NORMAL);
 		}
 
-		void SetDecalMode(const olc::DecalMode& mode)
+		void SetDecalMode(const olc::DecalMode& mode) override
 		{
 			if (mode != nDecalMode)
 			{


### PR DESCRIPTION
Thankyou for the olcPixelGameEngine.  I have just recently started using it for some small projects and I'm loving it.  As the title of this PR suggests, I compile my code with the -pedantic and -Weff-c++ flags.  This causes a bunch of warnings which I have attempted to fix in this series of commits.  Whether it is the right fix in every case I'm not sure.  For instance, for missing copy constructors/operator= I have just chosen to delete them.  It's fine for my code so far but is it the best decision overall?  I will leave that in your capable hands.