### PR TITLE
Fixed typo in example code

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -152,7 +152,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019, 2020
+	David Barr, aka javidx9, Â©OneLoneCoder 2018, 2019, 2020
 
 	2.01: Made renderer and platform static for multifile projects
 	2.02: Added Decal destructor, optimised Pixel constructor
@@ -216,7 +216,7 @@ class Example : public olc::PixelGameEngine
 public:
 	Example()
 	{
-		// Name you application
+		// Name your application
 		sAppName = "Example";
 	}
 


### PR DESCRIPTION
Just a small typo in the example code.
(The other line was edited by GitHub automatically. "©" Iso -> Utf-8, I guess)