### PR TITLE
Fixed test area upper limit: out of bound error

### DIFF
--- a/Videos/OneLoneCoder_PGE_CircleVsRect.cpp
+++ b/Videos/OneLoneCoder_PGE_CircleVsRect.cpp
@@ -149,7 +149,7 @@ public:
 		olc::vi2d vCurrentCell = object.vPos.floor();
 		olc::vi2d vTargetCell = vPotentialPosition;
 		olc::vi2d vAreaTL = (vCurrentCell.min(vTargetCell) - olc::vi2d(1, 1)).max({ 0,0 });
-		olc::vi2d vAreaBR = (vCurrentCell.max(vTargetCell) + olc::vi2d(1, 1)).min(vWorldSize);
+		olc::vi2d vAreaBR = (vCurrentCell.max(vTargetCell) + olc::vi2d(1, 1)).min(vWorldSize - olc::vi2d(1, 1));
 
 		olc::vf2d vRayToNearest;
 		 


### PR DESCRIPTION
The upper limit of the test area should be the string's maxlength - 1,
otherwise two errors occur when iterating through the area using the <=
operator: 1) addresses beyond the last element are indexed, triggering
UB; this occurs when object.vPos is on the last row of the vWorldMap
matrix. 2) the test area will warp around the screen; this happens when
object.vPos is on the last column of the matrix it will wrongly index
the element from the first column in the next row, potentially detecting
a collision with a rectangle in the wrong position. I believe this error
was not detected because the map is surrounded with walls.