### PR TITLE
Small optimisations and features...

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -1460,7 +1460,7 @@ namespace olc
 	}
 
 	// Needs testing
-	Sprite::RowView<Pixel> Sprite::operator[](std::size_t index) { return Sprite::RowView<Pixel>(pColData + (index * height), pColData + (index * (height + 1))); }
+	Sprite::RowView<Pixel> Sprite::operator[](std::size_t index) { return Sprite::RowView<Pixel>(pColData + (index * width), pColData + ((index + 1) * width)); }
 
 	Pixel Sprite::Sample(float x, float y) const noexcept
 	{


### PR DESCRIPTION
In short, I woke up one morning and thought, “let's optimize **_something_**…”…

### Additions:
**Macros related stuff (The uninteresting, boring part…):**
- `constexpr double pge_version`
    An alternative to the macro `PGE_VER`
- `constexpr bool bhas_cxx_17`
    A boolean set to `true` if `__cplusplus  >= 201703L` or if `defined(OLC_CXX_17)`
- `constexpr bool bhas_cxx_20`
    A boolean set to `true` if `__cplusplus  >= 202002L` or if `defined(OLC_CXX_20)`
- `OLC_CXX_20`
    A macro defined if `__cplusplus  >= 202002L` or if the user defined it on its own.
- `OLC_CXX_17`
    A macro defined if `namespace gfs = std::filesystem;` or `__cplusplus  >= 201703L` or `defined(OLC_CXX_20)` or if the user 
    defined it on it's own.
- `OLC_IF_CXX_17(x)`
    Pastes `x` if `defined(OLC_CXX_17)`
- `OLC_IF_NOT_CXX_17(x) `
    Pastes `x` if not `defined(OLC_CXX_17)`
- `OLC_IF_CXX_20(x)`
    Pastes `x` if `defined(OLC_CXX_20)`
- `OLC_IF_NOT_CXX_20(x)`
    Pastes `x` if not `defined(OLC_CXX_20)`

**Actual functionalities (Finally something interesting!):**
- `olc::readonly_string`
    A typedef defined to `std::string_view` if `defined(OLC_CXX_17)` or else to `std::string`
- `operator std::pair<T, T>()` in v2d_generic
    Because it's fun.
- `Sprite::Sprite(const olc::Sprite& other)`
    Copies an `olc::Sprite` in another one.
- `Sprite::Sprite(olc::Sprite&& other)` might be broken
   Moves an `olc::Sprite` in another one. `other` is left in an unspecified state.
- `Sprite::Sprite(int32_t w, int32_t h, Pixel* imagePixel)`
- `Sprite::RowView`
    This is a simple span-like structure for seeing a row of Pixels. I will need to find a better solution for that, though…
- `Pixel& Sprite::at(int32_t x, int32_t y)` (or v2d equivalent)
    Usable like in `std::[someContainer]` but you enter two values.
    Throws: `std::out_of_range` if `x > width || x < 0 || y > height || y < 0`
- `Pixel& Sprite::operator[]`
    Allows using of the syntax :
    ```cpp
    olc::Sprite spr(16, 16);
    olc::Pixel px1(spr[1][0]);
    for (olc::Pixel& pixel : spr[1]) // loop over the first row of the sprite
        pixel = pixel.inv(); // for example
    ```
    Currently it only supports `olc::Sprite::Mode::NORMAL`.
- Range support for `olc::Sprite`
    i.e. addition of a begin(), end() and size() method. (if someone wants reverse iterators, they can just use `std::make_reverse`…)
    I think it would be cool if could iterate over the screen by just writing `for (olc::Pixel pixel: Screen)`…
- `PixelF` is now a friend of `olc::Pixel`
- `.str()` of a `v2d_generic` with the values 1200 and 868 will now output `(1200, 868)` instead of `(1200,868)` (if I didn't break something, of course…)
- `Pixel::operator-=` now actually does a subtraction.

### Performace improvements (at least the obvious ones):
All comparisons were made against v2.14 when compiled on MSVC v19.28 and / or sometimes LLVM clang v11.1

Note: `random(0, 255)` is a hypothetical function to represent “a number”. i.e. it could have been a constant or something else, it does not matter. Normally it was a standard random generator (which is contrarily to popular belief faster than rand if you know how to use it) but I tested with some compile-time constants.

```cpp
// The performance improved by in average about 8–10% here
for (int32_t x = 0; x < ScreenWidth(); ++x)
	for (int32_t y = 0; y < ScreenHeight(); ++y) 
		Draw(x, y, olc::Pixel(random(0, 255), random(0, 255), random(0, 255)));
```
```cpp
// The performance improved by in average about 30 to 52% on MSVC, and on Clang between -2% to +8% here
for (int32_t x = 0; x < ScreenWidth(); ++x)
	for (int32_t y = 0; y < ScreenHeight(); ++y) 
		Draw(x, y, olc::Pixel(random(0, 255), random(0, 255), random(0, 255)).inv());
```
```cpp
// If I remove the elses in FillRect it improves by in average about 8–18% here (I will remove them of course)
bool OnUserUpdate([[maybe_unused]] float fElapsedTime) override {
	FillRect({ 0, 0 }, { ScreenWidth(), ScreenHeight() });
	FillRect({ 0, 0 }, { ScreenWidth(), ScreenHeight() });
	FillRect({ 0, 0 }, { ScreenWidth(), ScreenHeight() });
	FillRect({ 0, 0 }, { ScreenWidth(), ScreenHeight() });
}
```
And of course `olc::readonly_string` can be much faster than a normal `std::string`.

### Things to improve / verify that they even work :

- Sprite(olc::Sprite&& other)
    I'm not sure about this one…
- const everything?
    I might have forgotten to const the most things I could…
- the `return olc::FAIL;` in `PixelGameEngine::Construct`
- `std::thread t{ &PixelGameEngine::EngineThread, this };`
    This seems to work but I'm not 100% sure…
- `else if (nPixelMode == olc::Pixel::ALPHA)` in `PixelGameEngine::Draw` 
    I didn't test to see if it's slower; I'll change it if it's worse…
- Indentation?
    I might have broken the whole indentation of this header and if I did well I'm sorry.

**Note: I know that there are bugs; don't harass me just to say “Your code is buggy” please. I will fix them and then allow merging.**