### PR TITLE
Mod by 256 to get full 256 range of values

### DIFF
--- a/Videos/CarCrimeCity/Part1/olcPixelGameEngine.h
+++ b/Videos/CarCrimeCity/Part1/olcPixelGameEngine.h
@@ -133,7 +133,7 @@
 
 	Author
 	~~~~~~ 
-	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2018, 2019
 */
 
 ////////////////////////////////////////////////////////////////////////////////////////// 
@@ -160,7 +160,7 @@
 			// called once per frame, draws random coloured pixels
 			for (int x = 0; x < ScreenWidth(); x++)
 				for (int y = 0; y < ScreenHeight(); y++)
-					Draw(x, y, olc::Pixel(rand() % 255, rand() % 255, rand()% 255));
+					Draw(x, y, olc::Pixel(rand() % 256, rand() % 256, rand() % 256));
 			return true;
 		}
 	};

--- a/Videos/CarCrimeCity/Part1/olcPixelGameEngine.h
+++ b/Videos/CarCrimeCity/Part1/olcPixelGameEngine.h
@@ -133,7 +133,7 @@
 
 	Author
 	~~~~~~ 
-	David Barr, aka javidx9, �OneLoneCoder 2018, 2019
+	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019
 */
 
 ////////////////////////////////////////////////////////////////////////////////////////// 

--- a/Videos/CarCrimeCity/Part2/olcPixelGameEngine.h
+++ b/Videos/CarCrimeCity/Part2/olcPixelGameEngine.h
@@ -133,7 +133,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2018, 2019
 */
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -160,7 +160,7 @@
 			// called once per frame, draws random coloured pixels
 			for (int x = 0; x < ScreenWidth(); x++)
 				for (int y = 0; y < ScreenHeight(); y++)
-					Draw(x, y, olc::Pixel(rand() % 255, rand() % 255, rand()% 255));
+					Draw(x, y, olc::Pixel(rand() % 256, rand() % 256, rand() % 256));
 			return true;
 		}
 	};

--- a/Videos/CarCrimeCity/Part2/olcPixelGameEngine.h
+++ b/Videos/CarCrimeCity/Part2/olcPixelGameEngine.h
@@ -133,7 +133,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, �OneLoneCoder 2018, 2019
+	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019
 */
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Videos/SavingSedit/olcPixelGameEngine.h
+++ b/Videos/SavingSedit/olcPixelGameEngine.h
@@ -133,7 +133,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2018, 2019
 */
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -160,7 +160,7 @@
 			// called once per frame, draws random coloured pixels
 			for (int x = 0; x < ScreenWidth(); x++)
 				for (int y = 0; y < ScreenHeight(); y++)
-					Draw(x, y, olc::Pixel(rand() % 255, rand() % 255, rand()% 255));
+					Draw(x, y, olc::Pixel(rand() % 256, rand() % 256, rand() % 256));
 			return true;
 		}
 	};

--- a/Videos/SavingSedit/olcPixelGameEngine.h
+++ b/Videos/SavingSedit/olcPixelGameEngine.h
@@ -133,7 +133,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, �OneLoneCoder 2018, 2019
+	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019
 */
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/olcExampleProgram.cpp
+++ b/olcExampleProgram.cpp
@@ -21,7 +21,7 @@ public:
 		// called once per frame
 		for (int x = 0; x < ScreenWidth(); x++)
 			for (int y = 0; y < ScreenHeight(); y++)
-				Draw(x, y, olc::Pixel(rand() % 255, rand() % 255, rand()% 255));	
+				Draw(x, y, olc::Pixel(rand() % 256, rand() % 256, rand()% 256));	
 		return true;
 	}
 };


### PR DESCRIPTION
The example currently does a mod by 255 which would only produce a range of values from 0-254. This change updates the example to mod by 256 in order to get that last valid 255 of a uint8_t.