### PR TITLE
Place guard around UNUSED define

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -394,7 +394,9 @@ int main()
 	#define olcT(s) s
 #endif
 
-#define UNUSED(x) (void)(x)
+#if ! defined(UNUSED)
+  #define UNUSED(x) (void)(x)
+#endif
 
 // O------------------------------------------------------------------------------O
 // | PLATFORM SELECTION CODE, Thanks slavka!                                      |


### PR DESCRIPTION
Add guard code around UNUSED define to avoid redefinition compile errors. 