### PR TITLE
Fix for TransformedView::DrawPartialSprite

### DIFF
--- a/Extensions/olcPGEX_TransformedView.h
+++ b/Extensions/olcPGEX_TransformedView.h
@@ -449,7 +449,7 @@ namespace olc
 	void TransformedView::DrawPartialSprite(const olc::vf2d& pos, Sprite* sprite, const olc::vi2d& sourcepos, const olc::vi2d& size, const olc::vf2d& scale, uint8_t flip)
 	{
 		olc::vf2d vSpriteSize = size;
-		if (IsRectVisible(pos, size * scale))
+		if (IsRectVisible(pos, vSpriteSize * scale))
 		{
 			olc::vf2d vSpriteScaledSize = olc::vf2d(size) * m_vRecipPixel * m_vWorldScale * scale;
 			olc::vf2d vSpritePixelStep = 1.0f / olc::vf2d(float(sprite->width), float(sprite->height));


### PR DESCRIPTION
This is a fix for the TransformView::DrawPartialSprite, when using scaling and TileTransformedView at the same time.