### PR TITLE
Set Engine Thread name on Windows

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -856,6 +856,7 @@ namespace olc
 		virtual ~Platform() = default;
 		virtual olc::rcode ApplicationStartUp() = 0;
 		virtual olc::rcode ApplicationCleanUp() = 0;
+		virtual olc::rcode SetThreadName(const std::string&) = 0;
 		virtual olc::rcode ThreadStartUp() = 0;
 		virtual olc::rcode ThreadCleanUp() = 0;
 		virtual olc::rcode CreateGraphics(bool bFullScreen, bool bEnableVSYNC, const olc::vi2d& vViewPos, const olc::vi2d& vViewSize) = 0;
@@ -2889,6 +2890,8 @@ namespace olc
 
 	void PixelGameEngine::EngineThread()
 	{
+		platform->SetThreadName("OLC PGE Engine Thread");
+
 		// Allow platform to do stuff here if needed, since its now in the
 		// context of this thread
 		if (platform->ThreadStartUp() == olc::FAIL)	return;
@@ -4333,6 +4336,33 @@ namespace olc
 	public:
 		virtual olc::rcode ApplicationStartUp() override { return olc::rcode::OK; }
 		virtual olc::rcode ApplicationCleanUp() override { return olc::rcode::OK; }
+
+		virtual olc::rcode SetThreadName(const std::string& s) 
+		{
+			// Reference:
+			// https://docs.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2019#set-a-thread-name-by-throwing-an-exception
+
+			#pragma pack(push, 8)
+			struct THREADNAME_INFO
+			{
+				DWORD dwType;
+				LPCSTR szName;
+				DWORD dwThreadID;
+				DWORD dwFlags;
+			};
+			#pragma pack(pop)
+
+			THREADNAME_INFO info{ 0x1000, s.c_str(), 0xFFFFFFFF, 0 };
+
+			__try
+			{
+				RaiseException(0x406D1388, 0, sizeof(info) / sizeof(ULONG_PTR), reinterpret_cast<ULONG_PTR*>(&info));
+			}
+			__except(EXCEPTION_CONTINUE_EXECUTION) { }
+
+			return olc::rcode::OK;
+		}
+
 		virtual olc::rcode ThreadStartUp() override { return olc::rcode::OK; }
 
 		virtual olc::rcode ThreadCleanUp() override
@@ -4532,6 +4562,11 @@ namespace olc
 		virtual olc::rcode ApplicationCleanUp() override
 		{
 			XDestroyWindow(olc_Display, olc_Window);
+			return olc::rcode::OK;
+		}
+
+		virtual olc::rcode SetThreadName(const std::string&) override
+		{
 			return olc::rcode::OK;
 		}
 
@@ -4781,6 +4816,11 @@ namespace olc {
 		}
 
 		virtual olc::rcode ApplicationCleanUp() override
+		{
+			return olc::rcode::OK;
+		}
+
+		virtual olc::rcode SetThreadName(const std::string&) override
 		{
 			return olc::rcode::OK;
 		}
@@ -5097,6 +5137,9 @@ namespace olc
 
 		virtual olc::rcode ApplicationCleanUp() override 
 		{ ThreadCleanUp(); return olc::rcode::OK; }
+
+		virtual olc::rcode SetThreadName(const std::string&)
+		{ return olc::rcode::OK; }
 
 		virtual olc::rcode ThreadStartUp() override
 		{ return olc::rcode::OK; }


### PR DESCRIPTION
Windows debuggers can be informed with the name of thread using a
special exception type. This adds a new olc::Platform api to allow
setting a thread name, implmements it for windows, and calls it from the
enigne thread.

This is just a convenience for debugging on windows. It will cause the
VS Debugger to show the thread as "OLC PGE Engine Thread" as opposed to
the default "ucrtbased.dll thread"

Examples

Toolbar:
![image](https://user-images.githubusercontent.com/6598594/140556835-6d4d3b8c-9915-4d8d-858d-ba68af26841d.png)

Debug -> Windows -> Threads:
![image](https://user-images.githubusercontent.com/6598594/140556909-0d1f2fa3-d83f-4d26-8466-0f8b285768eb.png)
