### PR TITLE
PixelLerp for multiple colours

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -195,7 +195,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2018, 2019, 2020, 2021, 2022
+	David Barr, aka javidx9, Â©OneLoneCoder 2018, 2019, 2020, 2021, 2022
 */
 #pragma endregion
 
@@ -548,7 +548,16 @@ namespace olc
 
 	Pixel PixelF(float red, float green, float blue, float alpha = 1.0f);
 	Pixel PixelLerp(const olc::Pixel& p1, const olc::Pixel& p2, float t);
+	template<typename ...Args>
+	Pixel PixelLerp(float t, const Args& ...args)
+	{
+		std::array<Pixel, sizeof...(args)> pixels{args...};
+		const auto numint = pixels.size() - 1;
+		const auto idxint = static_cast<int>(t * numint);
+		const auto tout = (t - (idxint/numint)) * numint - idxint;
 
+		return PixelLerp(pixels.at(idxint), pixels.at(idxint+1), tout);
+	}
 
 	// O------------------------------------------------------------------------------O
 	// | USEFUL CONSTANTS                                                             |


### PR DESCRIPTION
I have added an overload for the `PixelLerp` function to take multiple colours and interpolate between them.

An example usage:
```c++
for (int i = 0; i < 255; i++)
{
	DrawLine({0, i}, {255, i}, olc::PixelLerp(i / 255.0f, olc::RED, olc::YELLOW, olc::GREEN));
}
```