### PR TITLE
Correct a misspell of dfbuffer in line 5577

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -5574,7 +5574,7 @@ namespace olc
 					vFiles.push_back(std::string(buffer));
 					delete[] buffer;
 #else
-					vFiles.push_back(std::string(dbuffer));
+					vFiles.push_back(std::string(dfbuffer));
 #endif
 				}
 


### PR DESCRIPTION
Hi, I know this is a really dumb thing, but i've found an error in the "olcPixelGameEngine.h" file, in line 5577.
![imagen](https://user-images.githubusercontent.com/84346214/205498512-a34dd961-5520-4d24-8563-cdf79e998be8.png)
The array dfbuffer was misspelled as dbuffer. That's the only change i've made.
PSA: I am not very experienced with programming neither with git, so i don't know if this is the proper way to submit this change.