### PR TITLE
Changes on closest functions for geom2d

### DIFF
--- a/utilities/olcUTIL_Geometry2D.h
+++ b/utilities/olcUTIL_Geometry2D.h
@@ -312,8 +312,25 @@ namespace olc::utils::geom2d
 	template<typename T1, typename T2>
 	inline olc::v2d_generic<T2> closest(const triangle<T1>& t, const olc::v2d_generic<T2>& p)
 	{
-		// TODO:
-		return olc::v2d_generic<T2>();
+		olc::utils::geom2d::line<T1> l{t.pos[0], t.pos[1]};
+		auto p0 = closest(l, p);
+		auto d0 = (p0 - p).mag2();
+
+		l.end = t.pos[2];
+		auto p1 = closest(l, p);
+		auto d1 = (p1 - p).mag2();
+
+		l.start = t.pos[1];
+		auto p2 = closest(l, p);
+		auto d2 = (p2 - p).mag2();
+
+		if((d0 <= d1) && (d0 <= d2)) {
+			return p0;
+		} else if((d1 <= d0) && (d1 <= d2)) {
+			return p1;
+		} else {
+			return p2;
+		}
 	}
 
 

--- a/utilities/olcUTIL_Geometry2D.h
+++ b/utilities/olcUTIL_Geometry2D.h
@@ -277,14 +277,14 @@ namespace olc::utils::geom2d
 
 	// Returns closest point to point
 	template<typename T1, typename T2>
-	inline olc::v2d_generic<T2> closest(const olc::v2d_generic<T1>& p1, const olc::v2d_generic<T2>& p2)
+	inline olc::v2d_generic<T1> closest(const olc::v2d_generic<T1>& p1, const olc::v2d_generic<T2>& p2)
 	{
 		return p1;
 	}
 
 	// Returns closest point on line to point
 	template<typename T1, typename T2>
-	inline olc::v2d_generic<T2> closest(const line<T1>& l, const olc::v2d_generic<T2>& p)
+	inline olc::v2d_generic<T1> closest(const line<T1>& l, const olc::v2d_generic<T2>& p)
 	{		
 		auto d = l.vector();
 		double u = std::clamp(double(d.dot(p - l.start)) / d.mag2(), 0.0, 1.0);
@@ -293,24 +293,24 @@ namespace olc::utils::geom2d
 
 	// Returns closest point on circle to point
 	template<typename T1, typename T2>
-	inline olc::v2d_generic<T2> closest(const circle<T1>& c, const olc::v2d_generic<T2>& p)
+	inline olc::v2d_generic<T1> closest(const circle<T1>& c, const olc::v2d_generic<T2>& p)
 	{		
 		return c.pos + olc::vd2d(p - c.pos).norm() * c.radius;
 	}
 
 	// Returns closest point on rectangle to point
 	template<typename T1, typename T2>
-	inline olc::v2d_generic<T2> closest(const rect<T1>& r, const olc::v2d_generic<T2>& p)
+	inline olc::v2d_generic<T1> closest(const rect<T1>& r, const olc::v2d_generic<T2>& p)
 	{
 		// This could be a "constrain" function hmmmm
 		// TODO: Not quite what i wanted, should restrain to boundary
-		return olc::v2d_generic<T2>{ std::clamp(p.x, r.pos.x, r.pos.x + r.size.x), std::clamp(p.y, r.pos.y, r.pos.y + r.size.y) };
+		return olc::v2d_generic<T1>{ std::clamp(p.x, r.pos.x, r.pos.x + r.size.x), std::clamp(p.y, r.pos.y, r.pos.y + r.size.y) };
 		
 	}
 
 	// Returns closest point on triangle to point
 	template<typename T1, typename T2>
-	inline olc::v2d_generic<T2> closest(const triangle<T1>& t, const olc::v2d_generic<T2>& p)
+	inline olc::v2d_generic<T1> closest(const triangle<T1>& t, const olc::v2d_generic<T2>& p)
 	{
 		olc::utils::geom2d::line<T1> l{t.pos[0], t.pos[1]};
 		auto p0 = closest(l, p);


### PR DESCRIPTION
Implements function closest on geom2d between point and triangle.
The closest function for circle and line have been slightly adjusted to give better results for integers.
The return type of closest have been changed to match the type of the shape, not the type of the point.