### PR TITLE
ConsoleCaptureStdOut fix

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -1248,6 +1248,7 @@ namespace olc
 		// Command Console Specific
 		bool bConsoleShow = false;
 		bool bConsoleSuspendTime = false;
+		bool bConsoleCapturingStdOut = false;
 		olc::Key keyConsoleExit = olc::Key::F1;
 		std::stringstream ssConsoleOutput;
 		std::streambuf* sbufOldCout = nullptr;
@@ -3486,7 +3487,12 @@ namespace olc
 
 	void PixelGameEngine::ConsoleCaptureStdOut(const bool bCapture)
 	{
-		if(bCapture)
+		if (bConsoleCapturingStdOut == bCapture)
+			return;
+
+		bConsoleCapturingStdOut = bCapture;
+
+		if (bCapture)
 			sbufOldCout = std::cout.rdbuf(ssConsoleOutput.rdbuf());
 		else
 			std::cout.rdbuf(sbufOldCout);


### PR DESCRIPTION
Currently, `ConsoleCaptureStdOut` function only works as expected when it's called once with each alternating argument and the first call to it having argument `true`:
```cpp
ConsoleCaptureStdOut(true);
ConsoleCaptureStdOut(false);
ConsoleCaptureStdOut(true);
ConsoleCaptureStdOut(false);
...
```
However, it produces unexpected results when function gets called with `false` argument first:
```cpp
ConsoleCaptureStdOut(false); // UNEXPECTED: std::cout redirected to nullptr
```
Or when there are 2+ consecutive calls with `true` argument:
```cpp
ConsoleCaptureStdOut(true);
ConsoleCaptureStdOut(true);
ConsoleCaptureStdOut(false); // UNEXPECTED: std::cout still points to console output
```
This PR fixes both edge cases.