### PR TITLE
added main header into extensions

### DIFF
--- a/extensions/olcPGEX_Graphics2D.h
+++ b/extensions/olcPGEX_Graphics2D.h
@@ -56,7 +56,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019
 */
 
 /*
@@ -71,6 +71,8 @@
 
 #ifndef OLC_PGEX_GFX2D
 #define OLC_PGEX_GFX2D
+
+#include "olcPixelGameEngine.h"
 
 #include <algorithm>
 #undef min

--- a/extensions/olcPGEX_Graphics3D.h
+++ b/extensions/olcPGEX_Graphics3D.h
@@ -61,12 +61,14 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2018
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2018
 */
 
 
 #ifndef OLC_PGEX_GFX3D
 #define OLC_PGEX_GFX3D
+
+#include "olcPixelGameEngine.h"
 
 #include <algorithm>
 #include <vector>

--- a/extensions/olcPGEX_Network.h
+++ b/extensions/olcPGEX_Network.h
@@ -51,7 +51,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019, 2020, 2021
 
 */
 

--- a/extensions/olcPGEX_PopUpMenu.h
+++ b/extensions/olcPGEX_PopUpMenu.h
@@ -157,6 +157,8 @@
 #ifndef OLC_PGEX_POPUPMENU_H
 #define OLC_PGEX_POPUPMENU_H
 
+#include "olcPixelGameEngine.h"
+
 #include <cstdint>
 
 namespace olc

--- a/extensions/olcPGEX_RayCastWorld.h
+++ b/extensions/olcPGEX_RayCastWorld.h
@@ -64,7 +64,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019, 2020
 
 	Revisions:
 	1.00:	Initial Release
@@ -74,6 +74,8 @@
 
 #ifndef OLC_PGEX_RAYCASTWORLD_H
 #define OLC_PGEX_RAYCASTWORLD_H
+
+#include "olcPixelGameEngine.h"
 
 #include <unordered_map>
 #include <algorithm>

--- a/extensions/olcPGEX_Sound.h
+++ b/extensions/olcPGEX_Sound.h
@@ -64,12 +64,14 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019
 */
 
 
 #ifndef OLC_PGEX_SOUND_H
 #define OLC_PGEX_SOUND_H
+
+#include "olcPixelGameEngine.h"
 
 #include <istream>
 #include <cstring>


### PR DESCRIPTION
Hi,
Without the main header in some extensions, the IDE's linters add many squiggly lines in the editor. Just cosmetic, but helps when developing...
Thanks 