### PR TITLE
fix LoadOBJFile features initial index

### DIFF
--- a/extensions/olcPGEX_Graphics3D.h
+++ b/extensions/olcPGEX_Graphics3D.h
@@ -61,7 +61,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2018
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2018
 */
 
 
@@ -925,10 +925,16 @@ namespace olc
 						char c = s.get();
 						if (c == ' ' || c == '/')
 						{
-							if (tokens[nTokenCount].size() > 0)
+							// nTokenCount starts in -1
+							if (nTokenCount > 0)
 							{
-								nTokenCount++;
+								if (tokens[nTokenCount].size() > 0)
+								{
+									nTokenCount++;
+								}
 							}
+							else
+								nTokenCount++;
 						}
 						else
 							tokens[nTokenCount].append(1, c);


### PR DESCRIPTION
Hi,
When parsing a 'f' line the first non junk character was skipping resulting in a crash when loading .obj files.

```
f 2/3 4/7 1/5
```
The number `2` was skipping.

Checking for `nTokenCount` first solves the issue.

In the CGE tutorial there was no `size()` check. I kept it because maybe there is a scenario where it is needed.

Thanks,
Bruno