### PR TITLE
Fix odd click behavior with multiple TextBox objects

### DIFF
--- a/extensions/olcPGEX_QuickGUI.h
+++ b/extensions/olcPGEX_QuickGUI.h
@@ -56,7 +56,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021, 2022
+	David Barr, aka javidx9, Â©OneLoneCoder 2019, 2020, 2021, 2022
 
 	Changes
 	~~~~~~~
@@ -212,10 +212,10 @@ namespace olc::QuickGUI
 		void Update(olc::PixelGameEngine* pge) override;
 		void Draw(olc::PixelGameEngine* pge) override;
 		void DrawDecal(olc::PixelGameEngine* pge) override;
+		static bool bBoxClicked;					// Whether or not a Textbox instance was clicked this frame.
 
 	protected:
 		bool m_bTextEdit = false;
-
 	};
 
 	// Creates a Button Control - a clickable, labelled rectangle
@@ -434,6 +434,7 @@ namespace olc::QuickGUI
 
 	void Manager::Update(olc::PixelGameEngine* pge)
 	{
+		TextBox::bBoxClicked=false;
 		for (auto& p : m_vControls) p->Update(pge);
 	}
 
@@ -536,6 +537,8 @@ namespace olc::QuickGUI
 
 
 #pragma region TextBox
+	bool TextBox::bBoxClicked=false;
+
 	TextBox::TextBox(olc::QuickGUI::Manager& manager, const std::string& text, const olc::vf2d& pos, const olc::vf2d& size)
 		: Label(manager, text, pos, size)
 	{
@@ -570,6 +573,7 @@ namespace olc::QuickGUI
 			
 			if (bPressed && !pge->IsTextEntryEnabled() && !m_bTextEdit)
 			{				
+				TextBox::bBoxClicked=true;
 				pge->TextEntryEnable(true, sText);
 				m_bTextEdit = true;
 			}
@@ -587,8 +591,10 @@ namespace olc::QuickGUI
 			
 			if (bPressed && m_bTextEdit)
 			{
-				sText = pge->TextEntryGetString();
-				pge->TextEntryEnable(false);
+				if(!TextBox::bBoxClicked){
+					sText = pge->TextEntryGetString();
+					pge->TextEntryEnable(false);
+				}
 				m_bTextEdit = false;
 			}
 		}	


### PR DESCRIPTION
When multiple TextBox objects are created via QuickGUI and you have one selected, if you click a TextBox that has a lower index in the list of controls, the Text Entry Mode will get enabled first and then immediately disabled due to a release that follows later in the control iteration loop.

To correct this, I have proposed a flag for the `TextBox` control that will get set if any box is clicked. If this flag is set, then any `TextBox` objects later in the loop will not cause the `TextEntryMode` to be disabled, as the previously selected `TextBox` control needs it. This also has the added bonus of preventing the text of further `TextBox` controls from being altered unexpectedly to whatever was clicked prior as well.

I'll add a small disclaimer here that this doesn't fix the issue across multiple managers since this value would be shared across all of them and there may be multiple managers active at once. I don't have an idea of how this can be solved at this time.