### PR TITLE
3 small additions (Win32 and generic)

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -526,6 +526,7 @@ int main()
 
 	#include <windows.h>
 	#undef _WINSOCKAPI_
+	#include <shellapi.h>
 #endif
 
 #if defined(OLC_PLATFORM_X11)
@@ -690,6 +691,7 @@ namespace olc
 		v2d_generic	 lerp(const v2d_generic& v1, const double t) { return this->operator*(T(1.0 - t)) + (v1 * T(t)); }
 		T dot(const v2d_generic& rhs) const { return this->x * rhs.x + this->y * rhs.y; }
 		T cross(const v2d_generic& rhs) const { return this->x * rhs.y - this->y * rhs.x; }
+		T dist(const v2d_generic& rhs) const { return std::sqrt(this->x - rhs.x * this->x - rhs.x + this->y - rhs.y * this->y - rhs.y); }
 		v2d_generic  operator +  (const v2d_generic& rhs) const { return v2d_generic(this->x + rhs.x, this->y + rhs.y); }
 		v2d_generic  operator -  (const v2d_generic& rhs) const { return v2d_generic(this->x - rhs.x, this->y - rhs.y); }
 		v2d_generic  operator *  (const T& rhs)           const { return v2d_generic(this->x * rhs, this->y * rhs); }
@@ -3896,7 +3898,7 @@ namespace olc
 
 		// Display Frame
 		renderer->UpdateViewport(vViewPos, vViewSize);
-		renderer->ClearBuffer(olc::BLACK, true);
+		//renderer->ClearBuffer(olc::BLACK, true);
 
 		// Layer 0 must always exist
 		vLayers[0].bUpdate = true;


### PR DESCRIPTION
- add #include <shellapi.h>; required to compile on my Win32 system
- add dist() method to vx2d vector class
- remove renderer->ClearBuffer() call during display; saves some cycles and required for some effects

--> please consider for merging into the mainline !