### PR TITLE
Allow multi file support for extensions

### DIFF
--- a/extensions/olcPGEX_Graphics2D.h
+++ b/extensions/olcPGEX_Graphics2D.h
@@ -56,7 +56,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019
 */
 
 /*
@@ -73,6 +73,9 @@
 #define OLC_PGEX_GFX2D
 
 #include <algorithm>
+
+#include "olcPixelGameEngine.h"
+
 #undef min
 #undef max
 

--- a/extensions/olcPGEX_Graphics2D.h
+++ b/extensions/olcPGEX_Graphics2D.h
@@ -56,7 +56,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, �OneLoneCoder 2019
+	David Barr, aka javidx9, ©OneLoneCoder 2019
 */
 
 /*

--- a/extensions/olcPGEX_Graphics3D.h
+++ b/extensions/olcPGEX_Graphics3D.h
@@ -206,7 +206,7 @@ namespace olc
 			void SetTransform(olc::GFX3D::mat4x4 &transform);
 			void SetTexture(olc::Sprite *texture);
 			//void SetMipMapTexture(olc::GFX3D::MipMap *texture);
-			void SetLightSource(uint32_t nSlot, uint32_t nType, olc::Pixel col, olc::GFX3D::vec3d pos, olc::GFX3D::vec3d dir = { 0.0f, 0.0f, 1.0f }, float fParam = 0.0f);
+			void SetLightSource(uint32_t nSlot, uint32_t nType, olc::Pixel col, olc::GFX3D::vec3d pos, olc::GFX3D::vec3d dir = { 0.0f, 0.0f, 1.0f, 1.0f }, float fParam = 0.0f);
 			uint32_t Render(std::vector<olc::GFX3D::triangle> &triangles, uint32_t flags = RENDER_CULL_CW | RENDER_TEXTURED | RENDER_DEPTH);
 			uint32_t Render(std::vector<olc::GFX3D::triangle> &triangles, uint32_t flags, int nOffset, int nCount);
 			uint32_t RenderLine(olc::GFX3D::vec3d &p1, olc::GFX3D::vec3d &p2, olc::Pixel col = olc::WHITE);

--- a/extensions/olcPGEX_Graphics3D.h
+++ b/extensions/olcPGEX_Graphics3D.h
@@ -61,7 +61,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2018
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2018
 */
 
 
@@ -74,6 +74,9 @@
 #include <sstream>
 #include <string>
 #include <cstdint>
+
+#include "olcPixelGameEngine.h"
+
 #undef min
 #undef max
 

--- a/extensions/olcPGEX_Graphics3D.h
+++ b/extensions/olcPGEX_Graphics3D.h
@@ -61,7 +61,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, �OneLoneCoder 2018
+	David Barr, aka javidx9, ©OneLoneCoder 2018
 */
 
 

--- a/extensions/olcPGEX_Network.h
+++ b/extensions/olcPGEX_Network.h
@@ -51,7 +51,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021
+	David Barr, aka javidx9, Â©OneLoneCoder 2019, 2020, 2021
 
 */
 

--- a/extensions/olcPGEX_PopUpMenu.h
+++ b/extensions/olcPGEX_PopUpMenu.h
@@ -159,6 +159,8 @@
 
 #include <cstdint>
 
+#include "olcPixelGameEngine.h"
+
 namespace olc
 {
 	namespace popup

--- a/extensions/olcPGEX_QuickGUI.h
+++ b/extensions/olcPGEX_QuickGUI.h
@@ -56,7 +56,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021, 2022, 2023, 2024
+	David Barr, aka javidx9, Â©OneLoneCoder 2019, 2020, 2021, 2022, 2023, 2024
 
 	Changes
 	~~~~~~~

--- a/extensions/olcPGEX_RayCastWorld.h
+++ b/extensions/olcPGEX_RayCastWorld.h
@@ -64,7 +64,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019, 2020
 
 	Revisions:
 	1.00:	Initial Release
@@ -77,6 +77,8 @@
 
 #include <unordered_map>
 #include <algorithm>
+
+#include "olcPixelGameEngine.h"
 
 namespace olc
 {

--- a/extensions/olcPGEX_RayCastWorld.h
+++ b/extensions/olcPGEX_RayCastWorld.h
@@ -64,7 +64,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, �OneLoneCoder 2019, 2020
+	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020
 
 	Revisions:
 	1.00:	Initial Release

--- a/extensions/olcPGEX_Sound.h
+++ b/extensions/olcPGEX_Sound.h
@@ -64,7 +64,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, �OneLoneCoder 2019
+	David Barr, aka javidx9, ©OneLoneCoder 2019
 */
 
 

--- a/extensions/olcPGEX_Sound.h
+++ b/extensions/olcPGEX_Sound.h
@@ -64,7 +64,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019
 */
 
 
@@ -76,6 +76,9 @@
 #include <climits>
 #include <condition_variable>
 #include <algorithm>
+
+#include "olcPixelGameEngine.h"
+
 #undef min
 #undef max
 

--- a/extensions/olcPGEX_SplashScreen.h
+++ b/extensions/olcPGEX_SplashScreen.h
@@ -58,7 +58,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021, 2022, 2023, 2024
+	David Barr, aka javidx9, Â©OneLoneCoder 2019, 2020, 2021, 2022, 2023, 2024
 
 	Revisions:
 	1.00:	Initial Release

--- a/extensions/olcPGEX_TransformedView.h
+++ b/extensions/olcPGEX_TransformedView.h
@@ -59,7 +59,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021, 2022, 2023, 2024
+	David Barr, aka javidx9, Â©OneLoneCoder 2019, 2020, 2021, 2022, 2023, 2024
 
 	Revisions:
 	1.00:	Initial Release

--- a/extensions/olcPGEX_Wireframe.h
+++ b/extensions/olcPGEX_Wireframe.h
@@ -57,7 +57,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021, 2022
+	David Barr, aka javidx9, ï¿½OneLoneCoder 2019, 2020, 2021, 2022
 
 	Revisions:
 	1.00:	Initial Release

--- a/extensions/olcPGEX_Wireframe.h
+++ b/extensions/olcPGEX_Wireframe.h
@@ -57,7 +57,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, �OneLoneCoder 2019, 2020, 2021, 2022
+	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021, 2022
 
 	Revisions:
 	1.00:	Initial Release


### PR DESCRIPTION
Added multi file support for the extensions by adding ``#include "olcPixelGameEngine.h"`` to headers that was missing it.

At the same time, olcPGEX_Graphics3D produces the following errors

```bash
In file included from ./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.cpp:2:
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:209:138: error: default member initializer for 'w' needed within definition of enclosing class 'GFX3D' outside of member functions
  209 |                         void SetLightSource(uint32_t nSlot, uint32_t nType, olc::Pixel col, olc::GFX3D::vec3d pos, olc::GFX3D::vec3d dir = { 0.0f, 0.0f, 1.0f }, float fParam = 0.0f);
      |                                                                                                                                                               ^
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:105:10: note: default member initializer declared here
  105 |                         float w = 1; // Need a 4th term to perform sensible matrix vector multiplication
      |                               ^
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:595:18: error: no viable overloaded '='
  595 |                         out_tri1.p[0] = *inside_points[0];
      |                         ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:100:10: note: candidate function (the implicit move assignment operator) not viable: expects an rvalue for 1st argument
  100 |                 struct vec3d
      |                        ^~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:631:18: error: no viable overloaded '='
  631 |                         out_tri1.p[0] = *inside_points[0];                      
      |                         ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:100:10: note: candidate function (the implicit move assignment operator) not viable: expects an rvalue for 1st argument
  100 |                 struct vec3d
      |                        ^~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:634:18: error: no viable overloaded '='
  634 |                         out_tri1.p[1] = *inside_points[1];
      |                         ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:100:10: note: candidate function (the implicit move assignment operator) not viable: expects an rvalue for 1st argument
  100 |                 struct vec3d
      |                        ^~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:646:18: error: no viable overloaded '='
  646 |                         out_tri2.p[1] = *inside_points[1];
      |                         ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:100:10: note: candidate function (the implicit move assignment operator) not viable: expects an rvalue for 1st argument
  100 |                 struct vec3d
      |                        ^~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:648:18: error: no viable overloaded '='
  648 |                         out_tri2.p[0] = out_tri1.p[2];
      |                         ~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:100:10: note: candidate function (the implicit move assignment operator) not viable: expects an rvalue for 1st argument
  100 |                 struct vec3d
      |                        ^~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:1018:22: error: no viable overloaded '='
 1018 |                         lights[nSlot].pos = pos;
      |                         ~~~~~~~~~~~~~~~~~ ^ ~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:100:10: note: candidate function (the implicit move assignment operator) not viable: expects an rvalue for 1st argument
  100 |                 struct vec3d
      |                        ^~~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:1019:22: error: no viable overloaded '='
 1019 |                         lights[nSlot].dir = dir;
      |                         ~~~~~~~~~~~~~~~~~ ^ ~~~
./include/olcPixelGameEngine/extensions/olcPGEX_Graphics3D.h:100:10: note: candidate function (the implicit move assignment operator) not viable: expects an rvalue for 1st argument
  100 |                 struct vec3d
      |                        ^~~~~
8 errors generated.
```

Which was fixed by adding the 4th term to the initializer list, default value for ``w`` 