### PR TITLE
Fix leak on failure to load renderable

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -2147,7 +2147,6 @@ namespace olc
 		}
 		else
 		{
-			pSprite.release();
 			pSprite = nullptr;
 			return olc::rcode::NO_FILE;
 		}


### PR DESCRIPTION
The line removed had it's return value discarded. The return value is an owning raw pointer to a sprite just created by the function, so discarding it caused a leak. This code was used to test it:
```cpp
bool OnUserUpdate(float fElapsedTime) override {
  renderable.Load("invalid_image.png"); // Attempt to load image that doesn't exist

  return true;
}
```
Before the change, a slow but steady increase in memory would happen with the previous code. After letting it run for a few minutes, the program reached 500 MB of used memory. After the change, no such increase in memory, and the same program takes 95 MB no matter how long it ran for.