### PR TITLE
Fix coordinate indices in non-depth gputasks

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -5613,8 +5613,8 @@ namespace olc
 				{
 					olc::Pixel p = task.vb[n].c;
 					glColor4ub(GLubyte(p.r * f[0]), GLubyte(p.g * f[1]), GLubyte(p.b * f[2]), GLubyte(p.a * f[3]));
-					glVertex4f(task.vb[n].p[4], task.vb[n].p[5], 0.0f, task.vb[n].p[3]);
-					glTexCoord2f(task.vb[n].p[0], task.vb[n].p[1]);
+					glTexCoord2f(task.vb[n].p[4], task.vb[n].p[5]);
+					glVertex4f(task.vb[n].p[0], task.vb[n].p[1], 0.0f, task.vb[n].p[3]);
 				}
 			}
 


### PR DESCRIPTION
This should fix `DrawRotatedDecal` having the wrong coordinates, and probably fixes other uses of `GPUTask` that don't use depth.

As far as I know, this replicates how `DrawDecal(const olc::DecalInstance& decal)` functioned.