### PR TITLE
Added Alt key

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -1007,7 +1007,7 @@ namespace olc
 		K0, K1, K2, K3, K4, K5, K6, K7, K8, K9,
 		F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12,
 		UP, DOWN, LEFT, RIGHT,
-		SPACE, TAB, SHIFT, CTRL, INS, DEL, HOME, END, PGUP, PGDN,
+		SPACE, TAB, SHIFT, CTRL, ALT, INS, DEL, HOME, END, PGUP, PGDN,
 		BACK, ESCAPE, RETURN, ENTER, PAUSE, SCROLL,
 		NP0, NP1, NP2, NP3, NP4, NP5, NP6, NP7, NP8, NP9,
 		NP_MUL, NP_DIV, NP_ADD, NP_SUB, NP_DECIMAL, PERIOD,
@@ -6799,7 +6799,7 @@ namespace olc
 			mapKeys[VK_BACK] = Key::BACK; mapKeys[VK_ESCAPE] = Key::ESCAPE; mapKeys[VK_RETURN] = Key::ENTER; mapKeys[VK_PAUSE] = Key::PAUSE;
 			mapKeys[VK_SCROLL] = Key::SCROLL; mapKeys[VK_TAB] = Key::TAB; mapKeys[VK_DELETE] = Key::DEL; mapKeys[VK_HOME] = Key::HOME;
 			mapKeys[VK_END] = Key::END; mapKeys[VK_PRIOR] = Key::PGUP; mapKeys[VK_NEXT] = Key::PGDN; mapKeys[VK_INSERT] = Key::INS;
-			mapKeys[VK_SHIFT] = Key::SHIFT; mapKeys[VK_CONTROL] = Key::CTRL;
+			mapKeys[VK_SHIFT] = Key::SHIFT; mapKeys[VK_CONTROL] = Key::CTRL; mapKeys[VK_MENU] = Key::ALT;
 			mapKeys[VK_SPACE] = Key::SPACE;
 
 			mapKeys[0x30] = Key::K0; mapKeys[0x31] = Key::K1; mapKeys[0x32] = Key::K2; mapKeys[0x33] = Key::K3; mapKeys[0x34] = Key::K4;
@@ -7127,6 +7127,7 @@ namespace olc
 			mapKeys[XK_Scroll_Lock] = Key::SCROLL; mapKeys[XK_Tab] = Key::TAB; mapKeys[XK_Delete] = Key::DEL; mapKeys[XK_Home] = Key::HOME;
 			mapKeys[XK_End] = Key::END; mapKeys[XK_Page_Up] = Key::PGUP; mapKeys[XK_Page_Down] = Key::PGDN;	mapKeys[XK_Insert] = Key::INS;
 			mapKeys[XK_Shift_L] = Key::SHIFT; mapKeys[XK_Shift_R] = Key::SHIFT; mapKeys[XK_Control_L] = Key::CTRL; mapKeys[XK_Control_R] = Key::CTRL;
+			mapKeys[XK_Alt_L] = Key::ALT; mapKeys[XK_Alt_R] = Key::ALT;
 			mapKeys[XK_space] = Key::SPACE; mapKeys[XK_period] = Key::PERIOD;
 
 			mapKeys[XK_0] = Key::K0; mapKeys[XK_1] = Key::K1; mapKeys[XK_2] = Key::K2; mapKeys[XK_3] = Key::K3; mapKeys[XK_4] = Key::K4;
@@ -7467,6 +7468,7 @@ namespace olc {
 					break;
 				case GLUT_ACTIVE_ALT:
 					if ('a' <= key && key <= 'z') key -= 32;
+					//	ptrPGE->olc_UpdateKeyState(Key::ALT, true);
 					break;
 				}
 
@@ -7488,7 +7490,7 @@ namespace olc {
 					break;
 				case GLUT_ACTIVE_ALT:
 					if ('a' <= key && key <= 'z') key -= 32;
-					//No ALT in PGE
+					//	ptrPGE->olc_UpdateKeyState(Key::ALT, false);
 					break;
 				}
 
@@ -7696,6 +7698,7 @@ namespace olc
 			mapKeys[DOM_PK_SPACE] = Key::SPACE; mapKeys[DOM_PK_TAB] = Key::TAB;
 			mapKeys[DOM_PK_SHIFT_LEFT] = Key::SHIFT; mapKeys[DOM_PK_SHIFT_RIGHT] = Key::SHIFT;
 			mapKeys[DOM_PK_CONTROL_LEFT] = Key::CTRL; mapKeys[DOM_PK_CONTROL_RIGHT] = Key::CTRL;
+			mapKeys[DOM_PK_ALT_LEFT] = Key::ALT; mapKeys[DOM_PK_ALT_RIGHT] = Key::ALT;
 			mapKeys[DOM_PK_INSERT] = Key::INS; mapKeys[DOM_PK_DELETE] = Key::DEL; mapKeys[DOM_PK_HOME] = Key::HOME;
 			mapKeys[DOM_PK_END] = Key::END; mapKeys[DOM_PK_PAGE_UP] = Key::PGUP; mapKeys[DOM_PK_PAGE_DOWN] = Key::PGDN;
 			mapKeys[DOM_PK_BACKSPACE] = Key::BACK; mapKeys[DOM_PK_ESCAPE] = Key::ESCAPE;


### PR DESCRIPTION
While working on a quick and dirty test/log tool earlier this year, I wanted to use the _Alt_ key to switch into the menu. I thought this might be useful for others as well, so I opened this PR with support for all platforms.

### Testing State
A test program can be found [here](https://gist.github.com/oblaser/f71a1f6521b7848bdac978176ced01e0).

&#x2705; `OLC_PLATFORM_WINAPI`
- _AltGr_ => _Ctrl_ + _Alt_

&#x2705; `OLC_PLATFORM_X11`
- _AltGr_ is not recognised at all

&#x274C; `OLC_PLATFORM_GLUT`
Added but commented out, see other modifier keys and the comment at [line 7451](https://github.com/OneLoneCoder/olcPixelGameEngine/blob/257469ce0ed7342034f865c7eec6cea0c87aea75/olcPixelGameEngine.h#L7451).

&#x1F533; `OLC_PLATFORM_EMSCRIPTEN`
- _I have no setup ready_