### PR TITLE
Add missing header, compilation instructions for MacOS

### DIFF
--- a/contributions/README.md
+++ b/contributions/README.md
@@ -29,7 +29,16 @@ These source code contributions enhance the functionality of the olcPixelGameEng
 ## MacOS Support
 * These will potentially be absorbed into main build
   * https://github.com/MumflrFumperdink/olcPGEMac
- 
+
+* compilation instructions for MacOS
+  * install libpng using homebrew
+  ```shell
+  brew install libpng
+  ```
+  * use the below compilation flags for MacOS
+  ```shell
+  clang++ olcExampleProgram.cpp -I/opt/homebrew/opt/libpng/include -L/opt/homebrew/opt/libpng/lib -framework OpenGL -framework GLUT -framework Cocoa -lpthread -lpng -std=c++20
+  ```
 ## Android & IOS Support
 * Fiddlier to setup, but pretty cool once going
   * https://github.com/Johnnyg63/OLCPGEMobileVisualStudio

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -441,6 +441,7 @@ int main()
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <cassert>
 #pragma endregion
 
 #define PGE_VER 230


### PR DESCRIPTION
Added compilation instructions to contributions/README.md

  * install libpng using homebrew
  ```shell
  brew install libpng
  ```
  * use the below compilation flags for MacOS
  ```shell
  clang++ olcExampleProgram.cpp -I/opt/homebrew/opt/libpng/include -L/opt/homebrew/opt/libpng/lib -framework OpenGL -framework GLUT -framework Cocoa -lpthread -lpng -std=c++20
  ```


Working application executable screenshot
<img width="1920" height="1080" alt="Screenshot 2026-03-03 at 3 04 05 AM" src="https://github.com/user-attachments/assets/402a7779-7325-41ae-a02e-c484551e6f7b" />
