### PR TITLE
Fix backspace bug in PixelGameEngine::UpdateTextEntry function

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -4406,10 +4406,17 @@ namespace olc
 				nTextEntryCursor = std::max(0, nTextEntryCursor - 1);
 			else if (sym == "_R")
 				nTextEntryCursor = std::min(int32_t(sTextEntryString.size()), nTextEntryCursor + 1);
-			else if (sym == "\b" && nTextEntryCursor > 0)
+			else if (sym == "\b")
 			{
-				sTextEntryString.erase(nTextEntryCursor - 1, 1);
-				nTextEntryCursor = std::max(0, nTextEntryCursor - 1);
+				if (nTextEntryCursor > 0)
+				{
+					sTextEntryString.erase(nTextEntryCursor - 1, 1);
+					nTextEntryCursor = std::max(0, nTextEntryCursor - 1);
+				}
+				else
+				{
+					// Consume the backspace character to prevent it from ending up in the TextEntry string
+				}
 			}
 			else if (sym == "_X" && size_t(nTextEntryCursor) < sTextEntryString.size())
 				sTextEntryString.erase(nTextEntryCursor, 1);


### PR DESCRIPTION
## Description

Fixed an issue in `PixelGameEngine::UpdateTextEntry` where pressing backspace at cursor position 0 would incorrectly insert the `\b` character into the text buffer.
Since this special character is encoded as ASCII 8, its presence leads to incorrect indexing in these calculations
```
int32_t ox = (c - 32) % 16;
int32_t oy = (c - 32) / 16;
```
causing index violation exception during the access to `std::vector`s.

## Problem

When `nTextEntryCursor == 0`, the condition handling backspace was not properly guarding against insertion, causing the backspace character to end up in the string.

## Reproduction

Used the `examples/TEST_QuickGUI.cpp` example for the `olcPGEX_QuickGUI.h` extension to catch the issue.

## Fix

Reworked the condition to explicitly handle that edge case, ensuring backspace input is always consumed but does not modify the text buffer.
Added an explicit branch for clarity, documenting the intended behavior when backspace is pressed at the start of the string.