### PR TITLE
Fix: XVisualInfo memory leak in Renderer_OGL10

### DIFF
--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -5320,6 +5320,13 @@ namespace olc
 #endif
 
 	public:
+		// cpt -- free memory for VisualInfo
+		~Renderer_OGL10() {
+			if (olc_VisualInfo) {
+        		X11::XFree(olc_VisualInfo);
+        		olc_VisualInfo = nullptr;
+    		}
+		}
 		void PrepareDevice() override
 		{
 #if defined(OLC_PLATFORM_GLUT)

--- a/olcPixelGameEngine.h
+++ b/olcPixelGameEngine.h
@@ -5320,13 +5320,15 @@ namespace olc
 #endif
 
 	public:
+#if defined(OLC_PLATFORM_X11)
 		// cpt -- free memory for VisualInfo
-		~Renderer_OGL10() {
-			if (olc_VisualInfo) {
-        		X11::XFree(olc_VisualInfo);
-        		olc_VisualInfo = nullptr;
-    		}
-		}
+    	~Renderer_OGL10() {
+        	if (olc_VisualInfo) {
+        	    X11::XFree(olc_VisualInfo);
+        	    olc_VisualInfo = nullptr;
+        	}
+    	}
+#endif
 		void PrepareDevice() override
 		{
 #if defined(OLC_PLATFORM_GLUT)


### PR DESCRIPTION
Destructor added to Renderer_OGL10 to free X11::XVisualInfo* olc_VisualInfo. Fixes minor memory leak.